### PR TITLE
luerl_eval:call/3: Support the 5-elements function tuple

### DIFF
--- a/src/luerl_eval.erl
+++ b/src/luerl_eval.erl
@@ -367,6 +367,10 @@ call({functiondef,L,Ps,B}, Args, St0) ->
     {Ret,St2} = functioncall(Func, Args, St1),
     %% Should do GC here.
     {Ret,St2};
+call({function,_,_,_,_}=Func, Args, St0) ->
+    {Ret,St1} = functioncall(Func, Args, St0),
+    %% Should do GC here.
+    {Ret,St1};
 call({function,_}=Func, Args, St0) ->
     {Ret,St1} = functioncall(Func, Args, St0),
     %% Should do GC here.


### PR DESCRIPTION
This fixes the case where a reference to a function is returned by a Lua
code and executed from an Erlang function.

Here's a code sample:

``` erlang
    % Load Lua script.
    {ok, Chunk} = luerl:loadfile("callback.lua"),
    % Run the script: it returns a reference to a function.
    St = luerl:init(),
    {[Fun | _], St1} = luerl:do(Chunk, St),
    % Execute the returned Lua function.
    luerl:call(Fun, [], St1).
```

The callback.lua script could be:

``` lua
    function callback()
        print("It works!")
    end
    return callback
```
