### PR TITLE
decode tables returned from luerl:eval/2 and luerl:evalfile/2

### DIFF
--- a/examples/hello/hello2-10.lua
+++ b/examples/hello/hello2-10.lua
@@ -1,0 +1,6 @@
+-- File     : hello2-10.lua
+-- Purpose  : Returning lua dicts
+-- See      : ./examples/hello/hello2.erl
+
+return {1,2,{3,'Hello World!'}}
+

--- a/examples/hello/hello2.erl
+++ b/examples/hello/hello2.erl
@@ -151,4 +151,8 @@ run() ->
     {Result14A,_} = luerl:call([confirm], [<<"Is it?">>], State14),
     io:format("(36) Well: ~s~n", [Result14A]),
 
+    % execute a file, get the decoded result of a table
+    {ok,Result15} = luerl:evalfile("./hello2-10.lua", State14),
+    io:format("(37) Decoded table: ~p~n", [Result15]),
+ 
     io:format("done~n").

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -43,9 +43,9 @@
 eval(Chunk) ->
     eval(Chunk, init()).
 
-eval(Chunk, St) ->
-    try do(Chunk, St) of
-        {Ret,_} -> {ok,Ret}
+eval(Chunk, St0) ->
+    try do(Chunk, St0) of
+        {Ret,St1} -> {ok, decode_list(Ret, St1)}
     catch
          _E:R -> {error, R} % {error, {E, R}} ? <- todo: decide
     end.
@@ -54,9 +54,9 @@ eval(Chunk, St) ->
 evalfile(Path) ->
     evalfile(Path, init()).
 
-evalfile(Path, St) ->
-    try dofile(Path, St) of
-        {Ret,_} -> {ok,Ret}
+evalfile(Path, St0) ->
+    try dofile(Path, St0) of
+        {Ret,St1} -> {ok, decode_list(Ret, St1)}
     catch
          _E:R -> {error, R} % {error, {E, R}} ? <- todo: decide
     end.


### PR DESCRIPTION
When using `luerl:eval/2` to return a table you get a `#tref` but no Lua state to extract it from. This patch will decode the return values of `eval/2` and `evalfile/2` before the Lua state that contains the `#tref` is thrown away. 

```
> luerl:eval("return { hello='there', ['how are']='you', 'well' }", Lua).
{ok,[[{1,<<"well">>},
      {<<"hello">>,<<"there">>},
      {<<"how are">>,<<"you">>}]]}
```
