### PR TITLE
Encode and decode functions from/to luerl

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Call a method already defined in the state. `Keys` is a list of keys to the meth
 
 #### luerl:gc(State) -> State.
  Runs the (experimental) garbage collector on a state and returns the new state.
+
+#### luerl:set_table(Path, Value, State) -> State.
+ Sets a value inside the Lua state. Value is automatically encoded.
+ 
+ You can use this function to expose an function to the Lua code by
+ using this interface:
+   fun(Args, State) -> {Results, State}
+ Args and Results must be a list of Luerl compatible erlang values.
  
 N.B. This interface is subject to change!
 
@@ -163,6 +171,13 @@ executes the call `table.pack("a", "b", 42)` in `State0`. E.g.:
     {Res,State1} = luerl:call_method([g,h,i], [<<"a">>,<<"b">>,42], State0)
 
 executes the call `g.h:i("a", "b", 42)` in `State0`.
+
+#### define a method in the state
+    State1 = luerl:set_table([inc], fun([Val], State) -> {[Val+1], State} end)
+
+the method can be called like this:
+
+    luerl:do(<<print(inc(4))>>", State1)
 
 For more examples see `examples/hello/hello2.erl`.
 

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -244,6 +244,13 @@ encode(L, St0) when is_list(L) ->
 			      end, {1.0,St0}, L),
     {T,St2} = luerl_emul:alloc_table(Es, St1),
     {T,St2};					%No more to do for now
+encode(F, St) when is_function(F, 2) ->
+    F1 = fun(Args, State) ->
+		 Args1 = decode_list(Args, State),
+		 {Res, State1} = F(Args1, State),
+		 encode_list(Res, State1)
+	 end,
+    {{function, F1}, St};
 encode(_, _) -> error(badarg).			%Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -276,8 +276,8 @@ decode({function,Fun}, _) -> {function,Fun};
 decode(#function{}=Fun, State) ->
     F = fun(Args) ->
 		{Args1, State1} = encode_list(Args, State),
-		{Ret, _State2} = luerl_emul:functioncall(Fun, Args1, State1),
-		Ret
+		{Ret, State2} = luerl_emul:functioncall(Fun, Args1, State1),
+		decode_list(Ret, State2)
 	end,
     {function, F};
 decode(_, _) -> error(badarg).			%Shouldn't have anything else

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -251,6 +251,13 @@ encode(F, St) when is_function(F, 2) ->
 		 encode_list(Res, State1)
 	 end,
     {{function, F1}, St};
+encode(F, St) when is_function(F, 1) ->
+    F1 = fun(Args, State) ->
+		 Args1 = decode_list(Args, State),
+		 Res = F(Args1),
+		 encode_list(Res, State)
+	 end,
+    {{function, F1}, St};
 encode(_, _) -> error(badarg).			%Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -273,4 +273,11 @@ decode(#tref{i=N}, St) ->
 	_Undefined -> error(badarg)
     end;
 decode({function,Fun}, _) -> {function,Fun};
+decode(#function{}=Fun, State) ->
+    F = fun(Args) ->
+		{Args1, State1} = encode_list(Args, State),
+		{Ret, _State2} = luerl_emul:functioncall(Fun, Args1, State1),
+		Ret
+	end,
+    {function, F};
 decode(_, _) -> error(badarg).			%Shouldn't have anything else

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -22,3 +22,17 @@ external_fun_test() ->
     ?assertEqual(BoolVal2, true),
     ?assertEqual(BoolVal3, true).
     
+return_lib_function_test() ->
+    State = luerl:init(),
+    {_, State1} = luerl:do(<<"function test()\n  return string.find  end\n">>, State),
+    {[{function, Fun}], _State2} = luerl:call_function([test], [1], State1),
+    {Res, _State3} = Fun([<<"barfooblafasel">>, <<"foo">>], State1),
+    ?assertEqual(Res, [4.0, 6.0]).
+
+define_fun_in_lua_test() ->
+    State = luerl:init(),
+    {_, State1} = luerl:do(<<"function mkadder(incby)\n  return function(i)\n    print(\"Call into Luerl!\")\n    return i + incby\n  end\nend\n">>, State),
+    {[{function, Fun}], _State2} = luerl:call_function([mkadder], [1], State1),
+    {[{function, Fun2}], _State3} = luerl:call_function([mkadder], [2], State1),
+    ?assertEqual(Fun([4]), [5.0]),
+    ?assertEqual(Fun2([4]), [6.0]).

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -1,0 +1,24 @@
+%%% @author Hans-Christian Esperer <hc@hcesperer.org>
+%%% @copyright (C) 2015, Hans-Christian Esperer
+%%% @doc
+%%
+%%% @end
+%%% Created : 11 Jan 2015 by Hans-Christian Esperer <hc@hcesperer.org>
+
+-module(luerl_funcall_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+external_fun_test() ->
+    State = luerl:init(),
+    F = fun([A], S) ->
+		{[A + 2, [A + 3, A + 4]], S}
+	end,
+    State1 = luerl:set_table([<<"testFun">>], F, State),
+    {_, State2} = luerl:do(<<"function test(i)\n  local a, b = testFun(i)\n return (a == i + 2), (b[1] == i + 3), (b[2] == i + 4) end">>, State1),
+    {Res, _State3} = luerl:call_function([test], [2], State2),
+    [BoolVal, BoolVal2, BoolVal3] = Res,
+    ?assertEqual(BoolVal, true),
+    ?assertEqual(BoolVal2, true),
+    ?assertEqual(BoolVal3, true).
+    

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -36,3 +36,12 @@ define_fun_in_lua_test() ->
     {[{function, Fun2}], _State3} = luerl:call_function([mkadder], [2], State1),
     ?assertEqual(Fun([4]), [5.0]),
     ?assertEqual(Fun2([4]), [6.0]).
+
+define_fun2_in_lua_test() ->
+    State = luerl:init(),
+    {_, State1} = luerl:do(<<"function mklist(numentries)\n  return function(entryval)\n    local list = {}\n    for i = 1,numentries do\n      list[i] = entryval\n    end\n    return list\n  end\nend\n">>, State),
+    {[{function, Fun}], _State2} = luerl:call_function([mklist], [5], State1),
+    {[{function, Fun2}], _State3} = luerl:call_function([mklist], [10], State1),
+    ?assertEqual(Fun([4]), [[{1,4.0}, {2,4.0}, {3,4.0}, {4,4.0}, {5,4.0}]]),
+    ?assertEqual(Fun2([4]), [[{1,4.0}, {2,4.0}, {3,4.0}, {4,4.0}, {5,4.0},
+			      {6,4.0}, {7,4.0}, {8,4.0}, {9,4.0}, {10,4.0}]]).

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -1,5 +1,17 @@
 %%% @author Hans-Christian Esperer <hc@hcesperer.org>
 %%% @copyright (C) 2015, Hans-Christian Esperer
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%       http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an "AS
+%%% IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+%%% express or implied.  See the License for the specific language
+%%% governing permissions and limitations under the License.
+%%%
 %%% @doc
 %%
 %%% @end

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -22,6 +22,19 @@ external_fun_test() ->
     ?assertEqual(BoolVal2, true),
     ?assertEqual(BoolVal3, true).
     
+external_nostate_fun_test() ->
+    State = luerl:init(),
+    F = fun([A]) ->
+		[A + 2, [A + 3, A + 4]]
+	end,
+    State1 = luerl:set_table([<<"testFun">>], F, State),
+    {_, State2} = luerl:do(<<"function test(i)\n  local a, b = testFun(i)\n return (a == i + 2), (b[1] == i + 3), (b[2] == i + 4) end">>, State1),
+    {Res, _State3} = luerl:call_function([test], [2], State2),
+    [BoolVal, BoolVal2, BoolVal3] = Res,
+    ?assertEqual(BoolVal, true),
+    ?assertEqual(BoolVal2, true),
+    ?assertEqual(BoolVal3, true).
+    
 return_lib_function_test() ->
     State = luerl:init(),
     {_, State1} = luerl:do(<<"function test()\n  return string.find  end\n">>, State),


### PR DESCRIPTION
I thought these small changes might be useful:

Allow external functions to be defined in a Luerl state using the luerl:set_table function.

Allow functions defined in Lua code to be returned by luerl:call_function in a way to be directly called by Erlang code.

Also I've added a small eunit test file in the test/ directory, though I'm not sure if that's how you want things, as test/ is in .gitignore...