### PR TITLE
Correctly handle return values for recursive __newindex calls

### DIFF
--- a/src/luerl_emul.erl
+++ b/src/luerl_emul.erl
@@ -233,7 +233,8 @@ set_table_key_key(#tref{i=N}, Key, Val, #luerl{ttab=Ts0}=St) ->
 		    Ts1 = ?SET_TABLE(N, T#table{t=Tab1}, Ts0),
 		    St#luerl{ttab=Ts1};
 		Meth when element(1, Meth) =:= function ->
-		    functioncall(Meth, [Key,Val], St);
+		    {_Ret, St1} = functioncall(Meth, [Key,Val], St),
+		    St1;
 		Meth -> set_table_key(Meth, Key, Val, St)
 	    end
     end.
@@ -251,7 +252,8 @@ set_table_int_key(#tref{i=N}, Key, I, Val, #luerl{ttab=Ts0}=St) ->
 		    Ts1 = ?SET_TABLE(N, T#table{a=Arr1}, Ts0),
 		    St#luerl{ttab=Ts1};
 		Meth when element(1, Meth) =:= function ->
-		    functioncall(Meth, [Key,Val], St);
+		    {_Ret, St1} = functioncall(Meth, [Key,Val], St),
+		    St1;
 		Meth -> set_table_key(Meth, Key, Val, St)
 	    end;
 	_ ->					%Key exists

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -70,3 +70,10 @@ define_fun2_in_lua_test() ->
     ?assertEqual(Fun([4]), [[{1,4.0}, {2,4.0}, {3,4.0}, {4,4.0}, {5,4.0}]]),
     ?assertEqual(Fun2([4]), [[{1,4.0}, {2,4.0}, {3,4.0}, {4,4.0}, {5,4.0},
 			      {6,4.0}, {7,4.0}, {8,4.0}, {9,4.0}, {10,4.0}]]).
+
+newindex_metamethod_test() ->
+    State = luerl:init(),
+    {[TVal, MVal], _State1} = luerl:do(<<"local t = {}\nlocal m = setmetatable({}, {__newindex = function (key, value)\n  t[key] = value\nend})\n\nm[123] = 456\nreturn t[123], m[123]">>, State),
+    ?assertEqual(TVal, 456.0),
+    ?assertEqual(MVal, nil).
+


### PR DESCRIPTION
The test case in this PR fails because `set_table_key_key` and `set_table_int_key` are expected to return `State`, but calling `functioncall` within those functions returns `{Return, State}`.

To pass the test case, pattern match on the result of `functioncall` and only return `State`.