### PR TITLE
Userdata suggestion

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -303,6 +303,11 @@ encode(F, St) when is_function(F, 1) ->
 		 encode_list(Res, State)
 	 end,
     {{function, F1}, St};
+encode({userdata, Obj}, St) ->
+    {#userdata{d = Obj}, St};
+encode({userdata, Obj, Meta}, St) ->
+    {MetaTab, _} = luerl_emul:get_table_keys(Meta, St),
+    {#userdata{d = Obj, m = MetaTab}, St};
 encode(_, _) -> error(badarg).			%Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].
@@ -336,6 +341,7 @@ decode(#function{}=Fun, State, _) ->
 		decode_list(Ret, State2)
 	end,
     {function, F};
+decode(#userdata{d=Obj}, St, _) -> Obj;
 decode(_, _, _) -> error(badarg).		%Shouldn't have anything else
 
 decode_table(N, St, In0) ->

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -341,7 +341,7 @@ decode(#function{}=Fun, State, _) ->
 		decode_list(Ret, State2)
 	end,
     {function, F};
-decode(#userdata{d=Obj}, St, _) -> Obj;
+decode(#userdata{d=Obj}, _, _) -> Obj;
 decode(_, _, _) -> error(badarg).		%Shouldn't have anything else
 
 decode_table(N, St, In0) ->

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -344,8 +344,17 @@ setmetatable([#tref{}=T,#tref{}=M|_], St) ->
     do_setmetatable(T, M, St);
 setmetatable([#tref{}=T,nil|_], St) ->
     do_setmetatable(T, nil, St);
+setmetatable([#userdata{} = U, #tref{}=M|_], St) ->
+    do_setmetatable(U, M, St);
 setmetatable(As, St) -> badarg_error(setmetatable, As, St).
 
+do_setmetatable(#userdata{} = U, M, St) ->
+    case luerl_emul:getmetamethod(U, <<"__metatable">>, St) of
+    nil ->
+        Ts = ?UPD_TABLE(U, fun (Tab) -> Tab#userdata{m=M} end, St#luerl.ttab),
+        {[U],St#luerl{ttab=Ts}};
+    _ -> badarg_error(setmetatable, [U], St)
+    end;
 do_setmetatable(#tref{i=N}=T, M, St) ->
     case luerl_emul:getmetamethod(T, <<"__metatable">>, St) of
 	nil ->


### PR DESCRIPTION
This is a work-in-progress, but is someway towards making userdata functional.

The remaining problem is that when the __newindex metatable function is called, at that point we've lost the variable name/location because unlike a table we don't have the indirect via the tref. This is manifested by the 'luerl:do("test[2] = 300", St2)' working, but the result does not update the userdata referenced.

Any suggestions?