### PR TITLE
Sandbox builder and reduction counting script runner

### DIFF
--- a/examples/hello/hello_sandbox.erl
+++ b/examples/hello/hello_sandbox.erl
@@ -1,0 +1,49 @@
+%% File    : hello_sandbox.erl
+%% Purpose : Brief demonstration of Luerl sandbox basics.
+%% Use     $ erlc hello_sandbox.erl && erl -pa ./ebin -s hello_sandbox run -s init stop -noshell
+%% Or      $ make hello_sandbox
+
+-module(hello_sandbox).
+-export([run/0]).
+
+run() ->
+    %% sandboxing globals
+    St0 = luerl_sandbox:init(),
+    {error, {lua_error, Reason, _}} = luerl_sandbox:run("return os.getenv(\"HOME\")"),
+    io:format("os.getenv with sandbox: ~p~n",[Reason]),
+
+    %% customizing sandbox
+    {[<<"number">>], _} = luerl_sandbox:run("return type(1)", luerl:init()),
+    {error,  {lua_error, _, _}} = luerl_sandbox:run("return type(1)", luerl_sandbox:init([['_G', type]])),
+
+    %% using sandboxed state outside of runner
+    try
+        luerl:do("return os.getenv(\"HOME\")", St0)
+    catch
+        _:_ ->
+            io:format("catch error with os.getenv(\"HOME\") with sandbox~n", [])
+    end,
+
+    %% script runner with reduction counting and process flags
+    MaxReductions = 100,
+    ProcessFlags = [{priority, low}],
+    {error, {reductions, R0}} = luerl_sandbox:run("a={}; for i=1,1000000 do a[i] = 5 end", St0, MaxReductions),
+    io:format("killed process with reductions ~p > 100~n",[R0]),
+    {error, {reductions, R1}} = luerl_sandbox:run("x = 'a'; while true do x = x .. x end", luerl:init(), MaxReductions, ProcessFlags),
+    io:format("killed process with reductions ~p > 100~n",[R1]),
+
+    %% unlimited reductions
+    UnlimitedReductions = 0,
+    {[], _} = luerl_sandbox:run("a={}; for i=1,10 do a[i] = 5 end", St0, UnlimitedReductions),
+    io:format("Finished running with unlimited reductions ~n",[]),
+
+    %% random seeding
+    Seed1 = {1,1,1}, Seed2 = {2,2,2},
+    {[RandA], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed1),
+    {[RandB], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed1),
+    {[RandC], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed2),
+    io:format("random seed ~p == ~p != ~p ~n",[RandA,RandB,RandC]),
+
+    done.
+
+

--- a/examples/hello/hello_sandbox.erl
+++ b/examples/hello/hello_sandbox.erl
@@ -27,22 +27,16 @@ run() ->
     %% script runner with reduction counting and process flags
     MaxReductions = 100,
     ProcessFlags = [{priority, low}],
+    Timeout = 1000,
     {error, {reductions, R0}} = luerl_sandbox:run("a={}; for i=1,1000000 do a[i] = 5 end", St0, MaxReductions),
     io:format("killed process with reductions ~p > 100~n",[R0]),
-    {error, {reductions, R1}} = luerl_sandbox:run("x = 'a'; while true do x = x .. x end", luerl:init(), MaxReductions, ProcessFlags),
+    {error, {reductions, R1}} = luerl_sandbox:run("x = 'a'; while true do x = x .. x end", luerl:init(), MaxReductions, ProcessFlags, Timeout),
     io:format("killed process with reductions ~p > 100~n",[R1]),
 
     %% unlimited reductions
     UnlimitedReductions = 0,
     {[], _} = luerl_sandbox:run("a={}; for i=1,10 do a[i] = 5 end", St0, UnlimitedReductions),
     io:format("Finished running with unlimited reductions ~n",[]),
-
-    %% random seeding
-    Seed1 = {1,1,1}, Seed2 = {2,2,2},
-    {[RandA], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed1),
-    {[RandB], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed1),
-    {[RandC], _} = luerl_sandbox:run("return math.random(100)", St0, MaxReductions, [], Seed2),
-    io:format("random seed ~p == ~p != ~p ~n",[RandA,RandB,RandC]),
 
     done.
 

--- a/src/luerl_sandbox.erl
+++ b/src/luerl_sandbox.erl
@@ -1,0 +1,119 @@
+%% Copyright (c) 2013-2017 Robert Virding
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% File    : luerl_sandbox.erl
+%% Authors : Tyler Butchart
+%% Purpose : Reduction limiting luerl sandbox.
+
+
+-module(luerl_sandbox).
+
+-export([init/0,init/1,init/2,
+         run/1,run/2,run/3,run/4,run/5]).
+
+-define(LUERL_GLOBAL, '_G').
+-define(SANDBOXED_VALUE, sandboxed).
+-define(SANDBOXED_GLOBALS, [
+        [?LUERL_GLOBAL, io],
+        [?LUERL_GLOBAL, file],
+        [?LUERL_GLOBAL, os, getenv],
+        [?LUERL_GLOBAL, package],
+        [?LUERL_GLOBAL, load],
+        [?LUERL_GLOBAL, loadfile],
+        [?LUERL_GLOBAL, require],
+        [?LUERL_GLOBAL, dofile],
+        [?LUERL_GLOBAL, load],
+        [?LUERL_GLOBAL, loadfile],
+        [?LUERL_GLOBAL, loadstring]
+    ]).
+
+%% init([, State|TablePaths[, TablePaths]]) -> State
+init() ->
+  init(luerl:init()).
+
+init(TablePaths) when is_list(TablePaths) ->
+  init(luerl:init(), TablePaths);
+init(St) ->
+  init(St, ?SANDBOXED_GLOBALS).
+
+
+init(St, []) -> luerl:gc(St);
+init(St0, [Path|Tail]) ->
+  St1 = luerl:set_table(Path, ?SANDBOXED_VALUE, St0),
+  init(St1, Tail).
+
+-ifdef(NEW_RAND).
+-define(RAND_SEED(S1,S2,S3), rand:seed(exs1024, {S1,S2,S3})).
+-else.
+-define(RAND_SEED(S1,S2,S3), random:seed(S1, S2, S3)).
+-endif.
+-define(NEW_SEED(), os:timestamp()).
+
+%% run(String|Binary|Form[, State[, MaxReductions|Flags[, Flags[, RandomSeed]]]]) -> {Term,State}|{error,Term}
+run(S) ->
+  run(S, init()).
+
+run(S, St) ->
+    run(S, St, 0, []).
+
+run(S, St, MaxR) when is_integer(MaxR) ->
+    run(S, St, MaxR, []);
+run(S, St, Flags) when is_list(Flags) ->
+    run(S, St, 0, Flags).
+
+run(S, St, MaxR, Flags) ->
+    run(S, St, MaxR, Flags, ?NEW_SEED()).
+
+run(S, St, 0, Flags, Seed) ->
+    Runner = start(self(), S, St, Flags, Seed),
+    receive_response(Runner);
+run(S, St, MaxR, Flags, Seed) ->
+    Runner = start(self(), S, St, Flags, Seed),
+    case wait_reductions(Runner, MaxR) of
+        {killed, R} -> {error, {reductions, R}};
+        ok -> receive_response(Runner)
+    end.
+
+start(Parent, S, St, Flags, {S1,S2,S3}) ->
+    spawn_opt(fun() ->
+        try
+            ?RAND_SEED(S1, S2, S3),
+            Reply = luerl:do(S, St),
+            erlang:send(Parent, {self(), Reply})
+        catch
+            error:Reason ->
+                erlang:send(Parent, {self(), {error, Reason}})
+        end
+     end, Flags).
+
+wait_reductions(Runner, MaxR) ->
+    case process_info(Runner, reductions) of
+        undefined ->
+            ok;
+        {reductions, R} when R >= MaxR ->
+            exit(Runner, kill),
+            {killed, R};
+        {reductions, _} ->
+            wait_reductions(Runner, MaxR)
+    end.
+
+-define(TIMEOUT, 100).
+receive_response(Runner) ->
+    receive
+        {Runner, Reply} -> Reply;
+        {error, Error} -> Error
+    after
+      ?TIMEOUT ->
+        {error, timeout}
+    end.


### PR DESCRIPTION
This implements a reduction counting script runner with an interface similar to `luerl:do/2`. I have been using this pattern to run untrusted lua scripts via luerl for my application. This pattern is best suited for short running scripts because it relies on limiting the number of reductions executed by the runner process.  

This method is able to stop 'fork bomb' scripts, eg:

```lua
x = 'a'; while true do x = x .. x end
```

It has the extra overhead of requiring a new process to be spawned to execute each request. The benefit  is we can easily control it's random state without dropping support for R17, as is the case with #84 . 

Here is an example of the full interface:

```erlang
Script = "x = 'a'; while true do x = x .. x end",
State = luerl:init(),
MaxReductions = 2000,
ProcessFlags = [{priority, low}],
RandomSeed = os:timestamp(),
{error, {reductions, R1}} =
    luerl_sandbox:run(Script, State, MaxReductions, ProcessFlags, RandomSeed)
```

I have also included a shortcut function for removing unsafe global tables and functions from an environment:

```erlang
luerl_sandbox:init(), %% default unsafe tables removed from new environment,
luerl_sandbox:init(luerl:init()), %% default unsafe tables removed from environment,
luerl_sandbox:init(luerl:init(), [ ['_G', math], ['_G', os, getenv] ]), %% custom tables removed from environment,

```

Here is my list of unsafe tables/functions that get removed by default:

```erlang
-define(SANDBOXED_GLOBALS, [
        [?LUERL_GLOBAL, io],
        [?LUERL_GLOBAL, file],
        [?LUERL_GLOBAL, os, getenv],
        [?LUERL_GLOBAL, package],
        [?LUERL_GLOBAL, load],
        [?LUERL_GLOBAL, loadfile],
        [?LUERL_GLOBAL, require],
        [?LUERL_GLOBAL, dofile],
        [?LUERL_GLOBAL, load],
        [?LUERL_GLOBAL, loadfile],
        [?LUERL_GLOBAL, loadstring]
    ]).
```

This is maybe best suited to be it's own separate application; let me know what you think!

run `cd examples/hello && make hello_sandbox` to try it out. 

```
erlc -I ../../src hello_sandbox.erl
erl -pa ../../ebin -s hello_sandbox run -s init stop -noshell
os.getenv with sandbox: {undef_function,<<"sandboxed">>}
catch error with os.getenv("HOME") with sandbox
killed process with reductions 2000 > 100
killed process with reductions 1999 > 100
Finished running with unlimited reductions 
random seed 7.0 == 7.0 != 75.0 
```