### PR TITLE
Preserve integer results for // and % operators

### DIFF
--- a/src/luerl_emul.erl
+++ b/src/luerl_emul.erl
@@ -1128,11 +1128,18 @@ op('/', A1, A2) ->
     numeric_op('/', A1, A2, <<"__div">>, fun (N1,N2) -> N1/N2 end);
 op('//', A1, A2) ->
     numeric_op('/', A1, A2, <<"__idiv">>,
-	       fun (N1,N2) when is_integer(N1), is_integer(N2) -> floor(N1/N2);
-		   (N1,N2) -> 0.0 + floor(N1/N2) end);
+	       fun (N1,N2) when is_integer(N1), is_integer(N2) ->
+               case N1 rem N2 of
+                 0 -> N1 div N2;
+                 _ -> floor(N1/N2)
+               end;
+             (N1,N2) -> 0.0 + floor(N1/N2)
+         end);
 op('%', A1, A2) ->
     numeric_op('%', A1, A2, <<"__mod">>,
-	       fun (N1,N2) -> N1 - floor(N1/N2)*N2 end);
+	       fun (N1,N2) when is_integer(N1), is_integer(N2) -> N1 rem N2;
+             (N1, N2) -> N1 - floor(N1/N2)*N2
+         end);
 op('^', A1, A2) ->
     numeric_op('^', A1, A2, <<"__pow">>,
 	       fun (N1,N2) -> math:pow(N1, N2) end);


### PR DESCRIPTION
The following sequence shows when does luerl lose integer precision:

f().
LF1 = "function funct(A,B) local C = A //  B return C end".
{ok, F1, S1} = luerl:load(LF1).
{_, S2} = luerl:do(F1, S1).
{[R], S3} = luerl:call_function([funct],[100000000000000000000000, 1],S2).
R.
99999999999999991611392


When integers are divided and the reminder is zero, we could keep the bignum representation of Erlang. This is also true with the % operator.

When luerl could be configured for integer precision (INT64, INT32, BIGNUM) This code shall be made compatible with the required integer representation. 