### PR TITLE
let git track the empty ebin folder, so erl -make work out of box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ _*
 *.swp
 *.swo
 .erlang.cookie
-ebin
+ebin/*.beam
 log
 erl_crash.dump
 .rebar


### PR DESCRIPTION
Use the same trick as otp repo does. This enable system without `GNU make` to build luerl using simple `erl -make`
The system includes *BSD and potentially Windows