### PR TITLE
Unicode characters in lua file

### DIFF
--- a/test/luerl_return_SUITE_data/check_unicode.lua
+++ b/test/luerl_return_SUITE_data/check_unicode.lua
@@ -1,0 +1,22 @@
+function check_hun(erl_str)
+    local lua_str = "árvíztűrő tükörfúrógép"
+    return check_values(erl_str, lua_str, 31)
+end
+
+function check_lambda(erl_str)
+    local lua_str = "λ"
+    return check_values(erl_str, lua_str, 2)
+end
+
+function check_aquarius(erl_str)
+    local lua_str = utf8.char(9810)
+    return check_values(erl_str, lua_str, 3)
+end
+
+function check_values(erl_str, lua_str, length)
+    assert(string.len(lua_str) == length, "invalid lua length")
+    assert(string.len(erl_str) == length, "invalid erl length")
+    assert(lua_str == erl_str, "different values")
+
+    return erl_str, lua_str, erl_str == lua_str, string.len(erl_str), string.len(lua_str)
+end


### PR DESCRIPTION
We tried to use unicode characters in luerl but found that is seems like unicode encoded twice.
I've found it is because of the usage the unicode:characters_to_binary(Cs2, unicode, unicode)
here the Cs2 is a list of characters, but the list is already utf8 encoded, so I think it should be just converted to binary 