### PR TITLE
Adds pid encoding /serialization capability

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -365,6 +365,8 @@ encode(F, St) when is_function(F, 1) ->
 		 encode_list(Res, State)
 	 end,
     {#erl_func{code=F1}, St};
+encode(Pid, St) when is_pid(Pid) -> 
+    {erlang:list_to_binary(erlang:pid_to_list(Pid)),St};
 encode({userdata,Data}, St) ->
     luerl_heap:alloc_userdata(Data, St);
 encode(_, _) -> error(badarg).			%Can't encode anything else


### PR DESCRIPTION
I don't know if this is legitimate.. My use case is to pass the pid to an helper to start a timer against a target process..
Should I use the `{userdata, Pid}` form?
==== Edit:
maybe yes.. I should 

Is there a better way to serialize the pid so to get it out directly within  the helper? 

Atm I'm using `{:userdata, self}` and within the helper i get `{:usdref, 0} = lua_userdata_pid`, which I have to decode:

```elixir
{:userdata, pid} = :luerl.decode(lua_userdata_pid, st)
```