### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Erlang/OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['24.3', '25.3']
+        rebar3: ['3.20']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{matrix.rebar3}}
+      - run: rebar3 do eunit, ct --cover, cover


### PR DESCRIPTION
Howdy @rvirding 👋 First and foremost, thanks for everything you do 🙏 We talked briefly in Slack about luerl and since those conversations I've been leveraging this library to empower a number of production systems so it's high time I start giving back. 

I was looking through the issues and PRs on the repo and noticed #89 which is now many years old. With the availability of GitHub Actions I think it might make more sense to go that route than TravisCI — are you open to that?  This PR introduces a single action for running tests. Happy to expand on this with your guidance.

One call out I did want to make: It seems there is a failing test on `develop` currently but when this change is ported to the `master` branch we can verify this action runs and tests all pass (here's an example PR on my fork: https://github.com/doomspork/luerl/pull/2).

Please let me know if there's any additional changes you'd like to make. Happy to incorporate any changes that would make this more useful to yourself and other contributors. 