### PR TITLE
Use MFA triplets instead of function references

### DIFF
--- a/examples/hello/Makefile
+++ b/examples/hello/Makefile
@@ -5,7 +5,7 @@ EXAMPLES = hello \
 	   hello_userdata \
 	   hello_userdata_new \
 	   hello_sandbox \
-       hello_funcalls
+	   hello_funcalls
 
 ROOTDIR = ../..
 SRCDIR  = $(ROOTDIR)/src

--- a/examples/hello/Makefile
+++ b/examples/hello/Makefile
@@ -4,7 +4,8 @@ EXAMPLES = hello \
 	   hello_table_new \
 	   hello_userdata \
 	   hello_userdata_new \
-	   hello_sandbox
+	   hello_sandbox \
+       hello_funcalls
 
 ROOTDIR = ../..
 SRCDIR  = $(ROOTDIR)/src

--- a/examples/hello/hello_funcalls.erl
+++ b/examples/hello/hello_funcalls.erl
@@ -1,0 +1,28 @@
+%% File     : hello_funcalls.erl
+%% Purpose  : Demonstration of various ways to expose Erlang functions to Luerl.
+%% Use      $ erlc hello_funcalls.erl && erl -pa ../../ebin -s hello_funcalls run -s init stop -noshell
+
+-module(hello_funcalls).
+
+-include("luerl.hrl").
+
+-export([run/0,mfa_function/3]).
+
+regular_function(Args,St) ->
+    io:format("regular_function(~p)\n", [Args]),
+    {[42], St}.
+
+mfa_function(StaticArgs,DynamicArgs,St) ->
+    io:format("mfa_function(~p, ~p)\n", [StaticArgs, DynamicArgs]),
+    {[42], St}.
+
+run() ->
+    LuaScript = <<"return hello_funcall(4, 5, 6)">>,
+    Lua = luerl:init(),
+    Lua1 = luerl:set_table([<<"hello_funcall">>], fun regular_function/2, Lua),
+    % The argument part of {M,F,A} won't get encoded, so that is why we can get away with passing a tuple here.
+    Lua2 = luerl:set_table([<<"hello_funcall">>], {hello_funcalls,mfa_function,{1,2}}, Lua),
+    {Res1, _} = luerl:do(LuaScript, Lua1),
+    io:format("regular_function got ~p~n", Res1),
+    {Res2, _} = luerl:do(LuaScript, Lua2),
+    io:format("mfa_function got ~p~n", Res2).

--- a/include/luerl.hrl
+++ b/include/luerl.hrl
@@ -114,8 +114,11 @@
 -record(erl_func,{code}).			%Erlang code (fun)
 -define(IS_ERLFUNC(F), is_record(F, erl_func)).
 
+-record(erl_mfa,{m,f,a}).           %Erlang code (MFA)
+-define(IS_ERLMFA(F), is_record(F, erl_mfa)).
+
 %% Test if it a function, of either sort.
--define(IS_FUNCTION(F), (?IS_FUNREF(F) orelse ?IS_ERLFUNC(F))).
+-define(IS_FUNCTION(F), (?IS_FUNREF(F) orelse ?IS_ERLFUNC(F) orelse ?IS_ERLMFA(F))).
 
 %% Testing for integers/integer floats or booleans.
 -define(IS_FLOAT_INT(N), (round(N) == N)).

--- a/src/Elixir.Luerl.New.erl
+++ b/src/Elixir.Luerl.New.erl
@@ -44,6 +44,9 @@
 %% Encoding and decoding.
 -export([encode/2,encode_list/2,decode/2,decode_list/2]).
 
+%%Helping with storing VM state
+-export([externalize/1,internalize/1]).
+
 init() ->
     luerl_new:init().
 
@@ -151,3 +154,9 @@ decode(St, V) ->
 
 decode_list(St, Lts) ->
     luerl_new:decode_list(Lts, St).
+
+externalize(St) ->
+    luerl_new:externalize(St).
+
+internalize(St) ->
+    luerl_new:internalize(St).

--- a/src/Elixir.Luerl.erl
+++ b/src/Elixir.Luerl.erl
@@ -42,6 +42,9 @@
 %% Encoding and decoding.
 -export([encode/2,encode_list/2,decode/2,decode_list/2]).
 
+%%Helping with storing VM state
+-export([externalize/1,internalize/1]).
+
 eval(St, Chunk) ->
      luerl:eval(Chunk, St).
 
@@ -155,3 +158,9 @@ decode_list(St, Lts) ->
 
 decode(St, V) ->
     luerl:decode(V, St).
+
+externalize(St) ->
+    luerl_new:externalize(St).
+
+internalize(St) ->
+    luerl_new:internalize(St).

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -302,6 +302,9 @@ do_stackframe(#call_frame{func=Funref,args=Args}, {Line,Trace}, St) ->
             {name,Name} = erlang:fun_info(Fun, name),
             FileName = get_filename(Module),
             {Line,[{{Module,Name},Args,[{file,FileName}]} | Trace]};
+        #erl_mfa{m=M,f=F,a=A} ->
+            FileName = get_filename(M),
+            {Line,[{{M,F},{A,Args},[{file,FileName}]} | Trace]};
         Other ->
             {Line,[{Other,Args,[{file,<<"-no-file-">>},{line,Line}]} | Trace]}
     end;
@@ -365,6 +368,8 @@ encode(F, St) when is_function(F, 1) ->
 		 encode_list(Res, State)
 	 end,
     {#erl_func{code=F1}, St};
+encode({M,F,A}, St) when is_atom(M) and is_atom(F) ->
+    {#erl_mfa{m=M,f=F,a=A}, St};
 encode({userdata,Data}, St) ->
     luerl_heap:alloc_userdata(Data, St);
 encode(_, _) -> error(badarg).			%Can't encode anything else
@@ -397,6 +402,7 @@ decode(#funref{}=Fun, State, _) ->
 	end,
     F;						%Just a bare fun
 decode(#erl_func{code=Fun}, _, _) -> Fun;
+decode(#erl_mfa{m=M,f=F,a=A}, _, _) -> {M,F,A};
 decode(_, _, _) -> error(badarg).		%Shouldn't have anything else
 
 decode_table(#tref{i=N}=T, St, In0) ->

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -33,7 +33,8 @@
 	 init/0,stop/1,gc/1,
          set_trace_func/2,clear_trace_func/1,
          set_trace_data/2,get_trace_data/1,
-	 get_stacktrace/1
+	 get_stacktrace/1,
+     externalize/1,internalize/1
 	]).
 
 %% Encoding and decoding.
@@ -424,3 +425,13 @@ decode_table(#tref{i=N}=T, St, In0) ->
 decode_userdata(U, St) ->
     {#userdata{d=Data},_} = luerl_heap:get_userdata(U, St),
     {userdata,Data}.
+
+%% Externalize and Internalize ensure that the VM state passed in
+%% can be stored externally or can be recreated from external storage.
+%% Currently very simple: only random state needs special treatment.
+
+externalize(S) ->
+    luerl_lib_math:externalize(S).
+
+internalize(S) ->
+    luerl_lib_math:internalize(S).

--- a/src/luerl.hrl
+++ b/src/luerl.hrl
@@ -114,8 +114,11 @@
 -record(erl_func,{code}).			%Erlang code (fun)
 -define(IS_ERLFUNC(F), is_record(F, erl_func)).
 
+-record(erl_mfa,{m,f,a}).           %Erlang code (MFA)
+-define(IS_ERLMFA(F), is_record(F, erl_mfa)).
+
 %% Test if it a function, of either sort.
--define(IS_FUNCTION(F), (?IS_FUNREF(F) orelse ?IS_ERLFUNC(F))).
+-define(IS_FUNCTION(F), (?IS_FUNREF(F) orelse ?IS_ERLFUNC(F) orelse ?IS_ERLMFA(F))).
 
 %% Testing for integers/integer floats or booleans.
 -define(IS_FLOAT_INT(N), (round(N) == N)).

--- a/src/luerl_heap.erl
+++ b/src/luerl_heap.erl
@@ -179,7 +179,7 @@ set_global_key(Key, Val, #luerl{g=G}=St) ->
 
 get_global_key(Key, #luerl{g=G}=St) ->
     get_table_key(G, Key, St).
- 
+
 %% set_table_key(Table, Key, Val, State) ->
 %%     {value,Value,State} | {meta,Method,Args,State} | {error,Error,State}
 %%
@@ -654,6 +654,8 @@ mark([#loop_frame{lvs=Lvs,stk=Stk,env=Env}|Todo], More0, GcT, GcE, GcU, GcF) ->
     mark(Todo, More1, GcT, GcE, GcU, GcF);
 %% Specifically catch these as they would match table key-value pair.
 mark([#erl_func{}|Todo], More, GcT, GcE, GcU, GcF) ->
+    mark(Todo, More, GcT, GcE, GcU, GcF);
+mark([#erl_mfa{}|Todo], More, GcT, GcE, GcU, GcF) ->
     mark(Todo, More, GcT, GcE, GcU, GcF);
 mark([#thread{}|Todo], More, GcT, GcE, GcU, GcF) ->
     mark(Todo, More, GcT, GcE, GcU, GcF);

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -21,7 +21,9 @@
 -include("luerl.hrl").
 
 %% The basic entry point to set up the function table.
--export([install/1]).
+-export([install/1,assert/3,collectgarbage/3,dofile/3,eprint/3,getmetatable/3,ipairs/3,load/3,loadfile/3,
+         loadstring/3,next/3,pairs/3,pcall/3,print/3,rawequal/3,rawget/3,rawlen/3,rawset/3,select/3,
+         setmetatable/3,tonumber/3,tostring/3,type/3,unpack/3]).
 
 %% Export some functions which can be called from elsewhere.
 -export([print/2,tostring/1,tostring/2,type/1]).
@@ -36,33 +38,33 @@ install(St) ->
 
 table() ->
     [{<<"_VERSION">>,<<"Lua 5.3">>},            %We are optimistic
-     {<<"assert">>,#erl_func{code=fun assert/2}},
-     {<<"collectgarbage">>,#erl_func{code=fun collectgarbage/2}},
-     {<<"dofile">>,#erl_func{code=fun dofile/2}},
-     {<<"eprint">>,#erl_func{code=fun eprint/2}},
-     {<<"error">>,#erl_func{code=fun basic_error/2}},
-     {<<"getmetatable">>,#erl_func{code=fun getmetatable/2}},
-     {<<"ipairs">>,#erl_func{code=fun ipairs/2}},
-     {<<"load">>,#erl_func{code=fun load/2}},
-     {<<"loadfile">>,#erl_func{code=fun loadfile/2}},
-     {<<"loadstring">>,#erl_func{code=fun loadstring/2}}, %For Lua 5.1 compatibility
-     {<<"next">>,#erl_func{code=fun next/2}},
-     {<<"pairs">>,#erl_func{code=fun pairs/2}},
-     {<<"pcall">>,#erl_func{code=fun pcall/2}},
-     {<<"print">>,#erl_func{code=fun print/2}},
-     {<<"rawequal">>,#erl_func{code=fun rawequal/2}},
-     {<<"rawget">>,#erl_func{code=fun rawget/2}},
-     {<<"rawlen">>,#erl_func{code=fun rawlen/2}},
-     {<<"rawset">>,#erl_func{code=fun rawset/2}},
-     {<<"select">>,#erl_func{code=fun select/2}},
-     {<<"setmetatable">>,#erl_func{code=fun setmetatable/2}},
-     {<<"tonumber">>,#erl_func{code=fun tonumber/2}},
-     {<<"tostring">>,#erl_func{code=fun tostring/2}},
-     {<<"type">>,#erl_func{code=fun type/2}},
-     {<<"unpack">>,#erl_func{code=fun unpack/2}}	%For Lua 5.1 compatibility
+     {<<"assert">>,#erl_mfa{m=luerl_lib_basic,f=assert,a=nil}},
+     {<<"collectgarbage">>,#erl_mfa{m=luerl_lib_basic,f=collectgarbage,a=nil}},
+     {<<"dofile">>,#erl_mfa{m=luerl_lib_basic,f=dofile,a=nil}},
+     {<<"eprint">>,#erl_mfa{m=luerl_lib_basic,f=eprint,a=nil}},
+     {<<"error">>,#erl_mfa{m=luerl_lib_basic,f=basic_error,a=nil}},
+     {<<"getmetatable">>,#erl_mfa{m=luerl_lib_basic,f=getmetatable,a=nil}},
+     {<<"ipairs">>,#erl_mfa{m=luerl_lib_basic,f=ipairs,a=nil}},
+     {<<"load">>,#erl_mfa{m=luerl_lib_basic,f=load,a=nil}},
+     {<<"loadfile">>,#erl_mfa{m=luerl_lib_basic,f=loadfile,a=nil}},
+     {<<"loadstring">>,#erl_mfa{m=luerl_lib_basic,f=loadstring,a=nil}}, %For Lua 5.1 compatibility
+     {<<"next">>,#erl_mfa{m=luerl_lib_basic,f=next,a=nil}},
+     {<<"pairs">>,#erl_mfa{m=luerl_lib_basic,f=pairs,a=nil}},
+     {<<"pcall">>,#erl_mfa{m=luerl_lib_basic,f=pcall,a=nil}},
+     {<<"print">>,#erl_mfa{m=luerl_lib_basic,f=print,a=nil}},
+     {<<"rawequal">>,#erl_mfa{m=luerl_lib_basic,f=rawequal,a=nil}},
+     {<<"rawget">>,#erl_mfa{m=luerl_lib_basic,f=rawget,a=nil}},
+     {<<"rawlen">>,#erl_mfa{m=luerl_lib_basic,f=rawlen,a=nil}},
+     {<<"rawset">>,#erl_mfa{m=luerl_lib_basic,f=rawset,a=nil}},
+     {<<"select">>,#erl_mfa{m=luerl_lib_basic,f=select,a=nil}},
+     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_basic,f=setmetatable,a=nil}},
+     {<<"tonumber">>,#erl_mfa{m=luerl_lib_basic,f=tonumber,a=nil}},
+     {<<"tostring">>,#erl_mfa{m=luerl_lib_basic,f=tostring,a=nil}},
+     {<<"type">>,#erl_mfa{m=luerl_lib_basic,f=type,a=nil}},
+     {<<"unpack">>,#erl_mfa{m=luerl_lib_basic,f=unpack,a=nil}}	%For Lua 5.1 compatibility
     ].
 
-assert(As, St) ->
+assert(_, As, St) ->
     case luerl_lib:boolean_value(As) of
 	true -> {As,St};
 	false ->
@@ -73,14 +75,14 @@ assert(As, St) ->
 	    lua_error({assert_error,M}, St)
     end.
 
-collectgarbage([], St) -> collectgarbage([<<"collect">>], St);
-collectgarbage([<<"collect">>|_], St) ->
+collectgarbage(_, [], St) -> collectgarbage(nil, [<<"collect">>], St);
+collectgarbage(_, [<<"collect">>|_], St) ->
     {[],luerl_heap:gc(St)};
     %% {[],St};					%No-op for the moment
-collectgarbage(_, St) ->			%Ignore everything else
+collectgarbage(_, _, St) ->			%Ignore everything else
     {[],St}.
 
-eprint(Args, St) ->
+eprint(_, Args, St) ->
     lists:foreach(fun (#tref{}=Tref) ->
 			  Tab = luerl_heap:get_table(Tref, St),
 			  io:format("~w ", [Tab]);
@@ -89,31 +91,31 @@ eprint(Args, St) ->
     io:nl(),
     {[],St}.
 
--spec basic_error(_, _) -> no_return().
+-spec basic_error(_, _, _) -> no_return().
 
-basic_error([{tref, _}=T|_], St0) ->
+basic_error(_, [{tref, _}=T|_], St0) ->
     case luerl_heap:get_metamethod(T, <<"__tostring">>, St0) of
         nil -> lua_error({error_call, T}, St0);
         Meta ->
             {[Ret|_], St1} = luerl_emul:functioncall(Meta, [T], St0),
             lua_error({error_call, Ret}, St1)
     end;
-basic_error([M|_], St) -> lua_error({error_call, M}, St);	%Never returns!
-basic_error(As, St) -> badarg_error(error, As, St).
+basic_error(_, [M|_], St) -> lua_error({error_call, M}, St);	%Never returns!
+basic_error(_, As, St) -> badarg_error(error, As, St).
 
 %% ipairs(Args, State) -> {[Func,Table,FirstKey],State}.
 %%  Return a function which on successive calls returns successive
 %%  key-value pairs of integer keys.
 
-ipairs([#tref{}=Tref|_], St) ->
+ipairs(_, [#tref{}=Tref|_], St) ->
     case luerl_heap:get_metamethod(Tref, <<"__ipairs">>, St) of
-	nil -> {[#erl_func{code=fun ipairs_next/2},Tref,0],St};
+	nil -> {[#erl_mfa{m=luerl_lib_basic,f=ipairs_next},Tref,0],St};
 	Meta -> luerl_emul:functioncall(Meta, [Tref], St)
     end;
-ipairs(As, St) -> badarg_error(ipairs, As, St).
-    
-ipairs_next([A], St) -> ipairs_next([A,0], St);
-ipairs_next([Tref,K|_], St) ->
+ipairs(_, As, St) -> badarg_error(ipairs, As, St).
+
+ipairs_next(_, [A], St) -> ipairs_next(nil, [A,0], St);
+ipairs_next(_, [Tref,K|_], St) ->
     %% Get the table.
     #table{a=Arr} = luerl_heap:get_table(Tref, St),
     Next = K + 1,
@@ -125,20 +127,20 @@ ipairs_next([Tref,K|_], St) ->
 %% pairs(Args, State) -> {[Func,Table,Key],State}.
 %%  Return a function to step over all the key-value pairs in a table.
 
-pairs([#tref{}=Tref|_], St) ->
+pairs(_, [#tref{}=Tref|_], St) ->
     case luerl_heap:get_metamethod(Tref, <<"__pairs">>, St) of
-	nil -> {[#erl_func{code=fun next/2},Tref,nil],St};
+	nil -> {[#erl_mfa{m=luerl_lib_basic,f=next},Tref,nil],St};
 	Meta -> luerl_emul:functioncall(Meta, [Tref], St)
     end;
-pairs(As, St) -> badarg_error(pairs, As, St).
+pairs(_, As, St) -> badarg_error(pairs, As, St).
 
 %% next(Args, State) -> {[Key,Value] | [nil], State}.
 %%  Given a table and a key return the next key-value pair in the
 %%  table, or nil if there is no next key. The key 'nil' gives the
 %%  first key-value pair.
 
-next([A], St) -> next([A,nil], St);
-next([#tref{}=Tref,K|_], St) ->
+next(_, [A], St) -> next(nil, [A,nil], St);
+next(_, [#tref{}=Tref,K|_], St) ->
     %% Get the table.
     #table{a=Arr,d=Dict} = luerl_heap:get_table(Tref, St),
     if K == nil ->
@@ -155,7 +157,7 @@ next([#tref{}=Tref,K|_], St) ->
 	    end;
        true -> next_key(K, Dict, St)
     end;
-next(As, St) -> badarg_error(next, As, St).
+next(_, As, St) -> badarg_error(next, As, St).
 
 next_index(I0, Arr, Dict, St) ->
     case next_index_loop(I0+1, Arr, array:size(Arr)) of
@@ -190,7 +192,7 @@ next_key(K, Dict, St) ->
 %%  string. print is not intended for formatted output, but only as a
 %%  quick way to show a value, for instance for debugging.
 
-print(Args, St0) ->
+print(_, Args, St0) ->
     St1 = lists:foldl(fun (A, S0) ->
 			      {[Str],S1} = tostring([A], S0),
 			      io:format("~ts ", [print_string(Str)]),
@@ -198,6 +200,7 @@ print(Args, St0) ->
 		      end, St0, Args),
     io:nl(),
     {[],St1}.
+print(Args, St0) -> print(nil, Args, St0).
 
 print_string(<<C/utf8,S/binary>>) -> [C|print_string(S)];
 print_string(<<_,S/binary>>) -> [$?|print_string(S)];
@@ -208,30 +211,30 @@ print_string(<<>>) -> [].
 %% rawget([Table,Key|_], State) -> {[Val],State)}.
 %% rawset([Table,Key,Value|_]], State) -> {[Table],State)}.
 
-rawequal([A1,A2|_], St) -> {[A1 =:= A2],St};
-rawequal(As, St) -> badarg_error(rawequal, As, St).
+rawequal(_, [A1,A2|_], St) -> {[A1 =:= A2],St};
+rawequal(_, As, St) -> badarg_error(rawequal, As, St).
 
-rawlen([A|_], St) when is_binary(A) -> {[float(byte_size(A))],St};
-rawlen([#tref{}=T|_], St) ->
+rawlen(_, [A|_], St) when is_binary(A) -> {[float(byte_size(A))],St};
+rawlen(_, [#tref{}=T|_], St) ->
     {[luerl_lib_table:raw_length(T, St)],St};
-rawlen(As, St) -> badarg_error(rawlen, As, St).
+rawlen(_, As, St) -> badarg_error(rawlen, As, St).
 
-rawget([#tref{}=Tref,Key|_], St) ->
+rawget(_, [#tref{}=Tref,Key|_], St) ->
     Val = luerl_heap:raw_get_table_key(Tref, Key, St),
     {[Val],St};
-rawget(As, St) -> badarg_error(rawget, As, St).
+rawget(_, As, St) -> badarg_error(rawget, As, St).
 
-rawset([Tref,nil=Key,_|_], St) ->
+rawset(_, [Tref,nil=Key,_|_], St) ->
     lua_error({illegal_index,Tref,Key}, St);
-rawset([#tref{}=Tref,Key,Val|_], St0) ->
+rawset(_, [#tref{}=Tref,Key,Val|_], St0) ->
     St1 = luerl_heap:raw_set_table_key(Tref, Key, Val, St0),
     {[Tref],St1};
-rawset(As, St) -> badarg_error(rawset, As, St).
+rawset(_, As, St) -> badarg_error(rawset, As, St).
 
 %% select(Args, State) -> {[Element],State}.
 
-select([<<$#>>|As], St) -> {[float(length(As))],St};
-select([A|As], St) ->
+select(_, [<<$#>>|As], St) -> {[float(length(As))],St};
+select(_, [A|As], St) ->
     %%io:fwrite("sel:~p\n", [[A|As]]),
     Len = length(As),
     case luerl_lib:arg_to_integer(A) of
@@ -239,7 +242,7 @@ select([A|As], St) ->
 	N when is_integer(N), N < 0 -> {select_back(-N, As, Len),St};
 	_ -> badarg_error(select, [A|As], St)
     end;
-select(As, St) -> badarg_error(select, As, St).
+select(_, As, St) -> badarg_error(select, As, St).
 
 select_front(N, As, Len) when N =< Len ->
     lists:nthtail(N-1, As);
@@ -249,20 +252,22 @@ select_back(N, As, Len) when N =< Len ->
     lists:nthtail(Len-N, As);
 select_back(_, As, _) -> As.
 
-tonumber([Arg], St) -> {[tonumber(luerl_lib:arg_to_number(Arg))],St};
-tonumber([Arg,B|_], St) -> {[tonumber(luerl_lib:arg_to_number(Arg, B))],St};
-tonumber(As, St) -> badarg_error(tonumber, As, St).
+tonumber(_, [Arg], St) -> {[tonumber(luerl_lib:arg_to_number(Arg))],St};
+tonumber(_, [Arg,B|_], St) -> {[tonumber(luerl_lib:arg_to_number(Arg, B))],St};
+tonumber(_, As, St) -> badarg_error(tonumber, As, St).
 
 tonumber(Num) when is_number(Num) -> Num;
 tonumber(_) -> nil.
 
-tostring([Arg|_], St) ->
+tostring(_, [Arg|_], St) ->
     case luerl_heap:get_metamethod(Arg, <<"__tostring">>, St) of
         nil -> {[tostring(Arg)],St};
         M when ?IS_FUNCTION(M) ->
             luerl_emul:functioncall(M, [Arg], St)  %Return {R,St1}
     end;
-tostring(As, St) -> badarg_error(tostring, As, St).
+tostring(_, As, St) -> badarg_error(tostring, As, St).
+
+tostring(As, St) -> tostring(nil, As, St).
 
 %% tostring([Arg|_], Stated) -> {String,State}.
 %%  Return the type as a string.
@@ -287,14 +292,16 @@ tostring(#funref{i=I}) ->                       %Functions defined in Lua
     iolist_to_binary([<<"function: ">>,integer_to_list(I)]);
 tostring(#erl_func{code=C}) ->                  %Erlang functions
     iolist_to_binary([<<"function: ">>,io_lib:write(C)]);
+tostring(#erl_mfa{m=M,f=F}) ->                  %Erlang MFA triplets
+    iolist_to_binary([<<"function: ">>,io_lib:write_atom(M),<<":">>,io_lib:write_atom(F)]);
 tostring(#thread{}) -> <<"thread">>;
 tostring(_) -> <<"unknown">>.
 
 %% type([Data|_], State) -> {Type,State}.
 %%  Return the type of the argument.
 
-type([Arg|_], St) -> {[type(Arg)],St};          %Only one return value!
-type(As, St) -> badarg_error(type, As, St).
+type(_, [Arg|_], St) -> {[type(Arg)],St};          %Only one return value!
+type(_, As, St) -> badarg_error(type, As, St).
 
 type(nil) -> <<"nil">>;
 type(N) when is_number(N) -> <<"number">>;
@@ -304,6 +311,7 @@ type(#tref{}) -> <<"table">>;
 type(#usdref{}) -> <<"userdata">>;
 type(#funref{}) -> <<"function">>;              %Functions defined in Lua
 type(#erl_func{}) -> <<"function">>;            %Internal functions
+type(#erl_mfa{}) -> <<"function">>;
 type(#thread{}) -> <<"thread">>;
 type(_) -> <<"unknown">>.
 
@@ -313,7 +321,7 @@ type(_) -> <<"unknown">>.
 %%  values, for tables and userdata it is the table of the object,
 %%  else the metatable for the type.
 
-getmetatable([Obj|_], St) ->
+getmetatable(_, [Obj|_], St) ->
     case luerl_heap:get_metatable(Obj, St) of
 	#tref{}=Meta ->
 	    #table{d=Dict} = luerl_heap:get_table(Meta, St),
@@ -323,14 +331,14 @@ getmetatable([Obj|_], St) ->
 	    end;
 	nil -> {[nil],St}
     end;
-getmetatable(As, St) -> badarg_error(getmetatable, As, St).
+getmetatable(_, As, St) -> badarg_error(getmetatable, As, St).
 
 
-setmetatable([#tref{}=T,#tref{}=M|_], St) ->
+setmetatable(_, [#tref{}=T,#tref{}=M|_], St) ->
     do_setmetatable(T, M, St);
-setmetatable([#tref{}=T,nil|_], St) ->
+setmetatable(_, [#tref{}=T,nil|_], St) ->
     do_setmetatable(T, nil, St);
-setmetatable(As, St) -> badarg_error(setmetatable, As, St).
+setmetatable(_, As, St) -> badarg_error(setmetatable, As, St).
 
 do_setmetatable(#tref{}=Tref, Meta, St0) ->
     case luerl_heap:get_metamethod(Tref, <<"__metatable">>, St0) of
@@ -343,7 +351,7 @@ do_setmetatable(#tref{}=Tref, Meta, St0) ->
 
 %% Do files.
 
-dofile(As, St) ->
+dofile(_, As, St) ->
     case luerl_lib:conv_list(As, [erl_string]) of
 	[File] ->
 	    Ret = luerl_comp:file(File),	%Compile the file
@@ -359,7 +367,7 @@ dofile_ret({error,_,_}, As, St) ->
 
 %% Load string and files.
 
-load(As, St) ->
+load(_, As, St) ->
     case luerl_lib:conv_list(As, [erl_string,lua_string,lua_string,lua_any]) of
 	[S|_] ->
 	    Ret = luerl_comp:string(S),		%Compile the string
@@ -367,15 +375,15 @@ load(As, St) ->
 	error -> badarg_error(load, As, St)
     end.
 
-loadfile(As, St) ->
+loadfile(_, As, St) ->
     case luerl_lib:conv_list(As, [erl_string,lua_string,lua_any]) of
 	[F|_] ->
 	    Ret = luerl_comp:file(F),		%Compile the file
 	    load_ret(Ret, St);
 	error -> badarg_error(loadfile, As, St)
     end.
- 
-loadstring(As, St) ->
+
+loadstring(_, As, St) ->
     case luerl_lib:conv_list(As, [erl_string]) of
 	[S] ->
 	    Ret = luerl_comp:string(S),		%Compile the string
@@ -390,7 +398,7 @@ load_ret({error,[{_,Mod,E}|_],_}, St) ->
     Msg = iolist_to_binary(Mod:format_error(E)),
     {[nil,Msg],St}.
 
-pcall([F|As], St0) ->
+pcall(_, [F|As], St0) ->
     try
 	{Rs,St1} = luerl_emul:functioncall(F, As, St0),
 	{[true|Rs],St1}
@@ -406,4 +414,4 @@ pcall([F|As], St0) ->
 
 %% Lua 5.1 compatibility functions.
 
-unpack(As, St) -> luerl_lib_table:unpack(As, St).
+unpack(_, As, St) -> luerl_lib_table:unpack(As, St).

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -21,9 +21,9 @@
 -include("luerl.hrl").
 
 %% The basic entry point to set up the function table.
--export([install/1,assert/3,collectgarbage/3,dofile/3,eprint/3,getmetatable/3,ipairs/3,load/3,loadfile/3,
-         loadstring/3,next/3,pairs/3,pcall/3,print/3,rawequal/3,rawget/3,rawlen/3,rawset/3,select/3,
-         setmetatable/3,tonumber/3,tostring/3,type/3,unpack/3]).
+-export([install/1,assert/3,basic_error/3,collectgarbage/3,dofile/3,eprint/3,getmetatable/3,ipairs/3,
+         ipairs_next/3,load/3,loadfile/3,loadstring/3,next/3,pairs/3,pcall/3,print/3,rawequal/3,
+         rawget/3,rawlen/3,rawset/3,select/3, setmetatable/3,tonumber/3,tostring/3,type/3,unpack/3]).
 
 %% Export some functions which can be called from elsewhere.
 -export([print/2,tostring/1,tostring/2,type/1]).
@@ -38,30 +38,30 @@ install(St) ->
 
 table() ->
     [{<<"_VERSION">>,<<"Lua 5.3">>},            %We are optimistic
-     {<<"assert">>,#erl_mfa{m=luerl_lib_basic,f=assert,a=nil}},
-     {<<"collectgarbage">>,#erl_mfa{m=luerl_lib_basic,f=collectgarbage,a=nil}},
-     {<<"dofile">>,#erl_mfa{m=luerl_lib_basic,f=dofile,a=nil}},
-     {<<"eprint">>,#erl_mfa{m=luerl_lib_basic,f=eprint,a=nil}},
-     {<<"error">>,#erl_mfa{m=luerl_lib_basic,f=basic_error,a=nil}},
-     {<<"getmetatable">>,#erl_mfa{m=luerl_lib_basic,f=getmetatable,a=nil}},
-     {<<"ipairs">>,#erl_mfa{m=luerl_lib_basic,f=ipairs,a=nil}},
-     {<<"load">>,#erl_mfa{m=luerl_lib_basic,f=load,a=nil}},
-     {<<"loadfile">>,#erl_mfa{m=luerl_lib_basic,f=loadfile,a=nil}},
-     {<<"loadstring">>,#erl_mfa{m=luerl_lib_basic,f=loadstring,a=nil}}, %For Lua 5.1 compatibility
-     {<<"next">>,#erl_mfa{m=luerl_lib_basic,f=next,a=nil}},
-     {<<"pairs">>,#erl_mfa{m=luerl_lib_basic,f=pairs,a=nil}},
-     {<<"pcall">>,#erl_mfa{m=luerl_lib_basic,f=pcall,a=nil}},
-     {<<"print">>,#erl_mfa{m=luerl_lib_basic,f=print,a=nil}},
-     {<<"rawequal">>,#erl_mfa{m=luerl_lib_basic,f=rawequal,a=nil}},
-     {<<"rawget">>,#erl_mfa{m=luerl_lib_basic,f=rawget,a=nil}},
-     {<<"rawlen">>,#erl_mfa{m=luerl_lib_basic,f=rawlen,a=nil}},
-     {<<"rawset">>,#erl_mfa{m=luerl_lib_basic,f=rawset,a=nil}},
-     {<<"select">>,#erl_mfa{m=luerl_lib_basic,f=select,a=nil}},
-     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_basic,f=setmetatable,a=nil}},
-     {<<"tonumber">>,#erl_mfa{m=luerl_lib_basic,f=tonumber,a=nil}},
-     {<<"tostring">>,#erl_mfa{m=luerl_lib_basic,f=tostring,a=nil}},
-     {<<"type">>,#erl_mfa{m=luerl_lib_basic,f=type,a=nil}},
-     {<<"unpack">>,#erl_mfa{m=luerl_lib_basic,f=unpack,a=nil}}	%For Lua 5.1 compatibility
+     {<<"assert">>,#erl_mfa{m=luerl_lib_basic,f=assert}},
+     {<<"collectgarbage">>,#erl_mfa{m=luerl_lib_basic,f=collectgarbage}},
+     {<<"dofile">>,#erl_mfa{m=luerl_lib_basic,f=dofile}},
+     {<<"eprint">>,#erl_mfa{m=luerl_lib_basic,f=eprint}},
+     {<<"error">>,#erl_mfa{m=luerl_lib_basic,f=basic_error}},
+     {<<"getmetatable">>,#erl_mfa{m=luerl_lib_basic,f=getmetatable}},
+     {<<"ipairs">>,#erl_mfa{m=luerl_lib_basic,f=ipairs}},
+     {<<"load">>,#erl_mfa{m=luerl_lib_basic,f=load}},
+     {<<"loadfile">>,#erl_mfa{m=luerl_lib_basic,f=loadfile}},
+     {<<"loadstring">>,#erl_mfa{m=luerl_lib_basic,f=loadstring}}, %For Lua 5.1 compatibility
+     {<<"next">>,#erl_mfa{m=luerl_lib_basic,f=next}},
+     {<<"pairs">>,#erl_mfa{m=luerl_lib_basic,f=pairs}},
+     {<<"pcall">>,#erl_mfa{m=luerl_lib_basic,f=pcall}},
+     {<<"print">>,#erl_mfa{m=luerl_lib_basic,f=print}},
+     {<<"rawequal">>,#erl_mfa{m=luerl_lib_basic,f=rawequal}},
+     {<<"rawget">>,#erl_mfa{m=luerl_lib_basic,f=rawget}},
+     {<<"rawlen">>,#erl_mfa{m=luerl_lib_basic,f=rawlen}},
+     {<<"rawset">>,#erl_mfa{m=luerl_lib_basic,f=rawset}},
+     {<<"select">>,#erl_mfa{m=luerl_lib_basic,f=select}},
+     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_basic,f=setmetatable}},
+     {<<"tonumber">>,#erl_mfa{m=luerl_lib_basic,f=tonumber}},
+     {<<"tostring">>,#erl_mfa{m=luerl_lib_basic,f=tostring}},
+     {<<"type">>,#erl_mfa{m=luerl_lib_basic,f=type}},
+     {<<"unpack">>,#erl_mfa{m=luerl_lib_basic,f=unpack}}	%For Lua 5.1 compatibility
     ].
 
 assert(_, As, St) ->

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -38,30 +38,30 @@ install(St) ->
 
 table() ->
     [{<<"_VERSION">>,<<"Lua 5.3">>},            %We are optimistic
-     {<<"assert">>,#erl_mfa{m=luerl_lib_basic,f=assert}},
-     {<<"collectgarbage">>,#erl_mfa{m=luerl_lib_basic,f=collectgarbage}},
-     {<<"dofile">>,#erl_mfa{m=luerl_lib_basic,f=dofile}},
-     {<<"eprint">>,#erl_mfa{m=luerl_lib_basic,f=eprint}},
-     {<<"error">>,#erl_mfa{m=luerl_lib_basic,f=basic_error}},
-     {<<"getmetatable">>,#erl_mfa{m=luerl_lib_basic,f=getmetatable}},
-     {<<"ipairs">>,#erl_mfa{m=luerl_lib_basic,f=ipairs}},
-     {<<"load">>,#erl_mfa{m=luerl_lib_basic,f=load}},
-     {<<"loadfile">>,#erl_mfa{m=luerl_lib_basic,f=loadfile}},
-     {<<"loadstring">>,#erl_mfa{m=luerl_lib_basic,f=loadstring}}, %For Lua 5.1 compatibility
-     {<<"next">>,#erl_mfa{m=luerl_lib_basic,f=next}},
-     {<<"pairs">>,#erl_mfa{m=luerl_lib_basic,f=pairs}},
-     {<<"pcall">>,#erl_mfa{m=luerl_lib_basic,f=pcall}},
-     {<<"print">>,#erl_mfa{m=luerl_lib_basic,f=print}},
-     {<<"rawequal">>,#erl_mfa{m=luerl_lib_basic,f=rawequal}},
-     {<<"rawget">>,#erl_mfa{m=luerl_lib_basic,f=rawget}},
-     {<<"rawlen">>,#erl_mfa{m=luerl_lib_basic,f=rawlen}},
-     {<<"rawset">>,#erl_mfa{m=luerl_lib_basic,f=rawset}},
-     {<<"select">>,#erl_mfa{m=luerl_lib_basic,f=select}},
-     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_basic,f=setmetatable}},
-     {<<"tonumber">>,#erl_mfa{m=luerl_lib_basic,f=tonumber}},
-     {<<"tostring">>,#erl_mfa{m=luerl_lib_basic,f=tostring}},
-     {<<"type">>,#erl_mfa{m=luerl_lib_basic,f=type}},
-     {<<"unpack">>,#erl_mfa{m=luerl_lib_basic,f=unpack}}	%For Lua 5.1 compatibility
+     {<<"assert">>,#erl_mfa{m=?MODULE,f=assert}},
+     {<<"collectgarbage">>,#erl_mfa{m=?MODULE,f=collectgarbage}},
+     {<<"dofile">>,#erl_mfa{m=?MODULE,f=dofile}},
+     {<<"eprint">>,#erl_mfa{m=?MODULE,f=eprint}},
+     {<<"error">>,#erl_mfa{m=?MODULE,f=basic_error}},
+     {<<"getmetatable">>,#erl_mfa{m=?MODULE,f=getmetatable}},
+     {<<"ipairs">>,#erl_mfa{m=?MODULE,f=ipairs}},
+     {<<"load">>,#erl_mfa{m=?MODULE,f=load}},
+     {<<"loadfile">>,#erl_mfa{m=?MODULE,f=loadfile}},
+     {<<"loadstring">>,#erl_mfa{m=?MODULE,f=loadstring}}, %For Lua 5.1 compatibility
+     {<<"next">>,#erl_mfa{m=?MODULE,f=next}},
+     {<<"pairs">>,#erl_mfa{m=?MODULE,f=pairs}},
+     {<<"pcall">>,#erl_mfa{m=?MODULE,f=pcall}},
+     {<<"print">>,#erl_mfa{m=?MODULE,f=print}},
+     {<<"rawequal">>,#erl_mfa{m=?MODULE,f=rawequal}},
+     {<<"rawget">>,#erl_mfa{m=?MODULE,f=rawget}},
+     {<<"rawlen">>,#erl_mfa{m=?MODULE,f=rawlen}},
+     {<<"rawset">>,#erl_mfa{m=?MODULE,f=rawset}},
+     {<<"select">>,#erl_mfa{m=?MODULE,f=select}},
+     {<<"setmetatable">>,#erl_mfa{m=?MODULE,f=setmetatable}},
+     {<<"tonumber">>,#erl_mfa{m=?MODULE,f=tonumber}},
+     {<<"tostring">>,#erl_mfa{m=?MODULE,f=tostring}},
+     {<<"type">>,#erl_mfa{m=?MODULE,f=type}},
+     {<<"unpack">>,#erl_mfa{m=?MODULE,f=unpack}}	%For Lua 5.1 compatibility
     ].
 
 assert(_, As, St) ->
@@ -109,7 +109,7 @@ basic_error(_, As, St) -> badarg_error(error, As, St).
 
 ipairs(_, [#tref{}=Tref|_], St) ->
     case luerl_heap:get_metamethod(Tref, <<"__ipairs">>, St) of
-	nil -> {[#erl_mfa{m=luerl_lib_basic,f=ipairs_next},Tref,0],St};
+	nil -> {[#erl_mfa{m=?MODULE,f=ipairs_next},Tref,0],St};
 	Meta -> luerl_emul:functioncall(Meta, [Tref], St)
     end;
 ipairs(_, As, St) -> badarg_error(ipairs, As, St).
@@ -129,7 +129,7 @@ ipairs_next(_, [Tref,K|_], St) ->
 
 pairs(_, [#tref{}=Tref|_], St) ->
     case luerl_heap:get_metamethod(Tref, <<"__pairs">>, St) of
-	nil -> {[#erl_mfa{m=luerl_lib_basic,f=next},Tref,nil],St};
+	nil -> {[#erl_mfa{m=?MODULE,f=next},Tref,nil],St};
 	Meta -> luerl_emul:functioncall(Meta, [Tref], St)
     end;
 pairs(_, As, St) -> badarg_error(pairs, As, St).

--- a/src/luerl_lib_bit32.erl
+++ b/src/luerl_lib_bit32.erl
@@ -22,7 +22,8 @@
 
 -include("luerl.hrl").
 
--export([install/1]).
+-export([install/1,fband/3,fbnot/3,fbor/3,fbtest/3,fbxor/3,flshift/3,frshift/3,
+         farshift/3,flrotate/3,frrotate/3,fextract/3,freplace/3]).
 
 -import(luerl_lib, [badarg_error/3]).	%Shorten this
 
@@ -36,21 +37,21 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"band">>,#erl_func{code=fun fband/2}},
-     {<<"bnot">>,#erl_func{code=fun fbnot/2}},
-     {<<"bor">>,#erl_func{code=fun fbor/2}},
-     {<<"btest">>,#erl_func{code=fun fbtest/2}},
-     {<<"bxor">>,#erl_func{code=fun fbxor/2}},
-     {<<"lshift">>,#erl_func{code=fun flshift/2}},
-     {<<"rshift">>,#erl_func{code=fun frshift/2}},
-     {<<"arshift">>,#erl_func{code=fun farshift/2}},
-     {<<"lrotate">>,#erl_func{code=fun flrotate/2}},
-     {<<"rrotate">>,#erl_func{code=fun frrotate/2}},
-     {<<"extract">>,#erl_func{code=fun fextract/2}},
-     {<<"replace">>,#erl_func{code=fun freplace/2}}
+    [{<<"band">>,#erl_mfa{m=luerl_lib_bit32,f=fband,a=nil}},
+     {<<"bnot">>,#erl_mfa{m=luerl_lib_bit32,f=fbnot,a=nil}},
+     {<<"bor">>,#erl_mfa{m=luerl_lib_bit32,f=fbor,a=nil}},
+     {<<"btest">>,#erl_mfa{m=luerl_lib_bit32,f=fbtest,a=nil}},
+     {<<"bxor">>,#erl_mfa{m=luerl_lib_bit32,f=fbxor,a=nil}},
+     {<<"lshift">>,#erl_mfa{m=luerl_lib_bit32,f=flshift,a=nil}},
+     {<<"rshift">>,#erl_mfa{m=luerl_lib_bit32,f=frshift,a=nil}},
+     {<<"arshift">>,#erl_mfa{m=luerl_lib_bit32,f=farshift,a=nil}},
+     {<<"lrotate">>,#erl_mfa{m=luerl_lib_bit32,f=flrotate,a=nil}},
+     {<<"rrotate">>,#erl_mfa{m=luerl_lib_bit32,f=frrotate,a=nil}},
+     {<<"extract">>,#erl_mfa{m=luerl_lib_bit32,f=fextract,a=nil}},
+     {<<"replace">>,#erl_mfa{m=luerl_lib_bit32,f=freplace,a=nil}}
      ].
 
-fband(As, St) ->
+fband(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	L when is_list(L) -> {[aband(L)], St};
 	error -> badarg_error('band', As, St)
@@ -62,7 +63,7 @@ aband([X|T]) -> aband(T, checkint32(X)).
 aband([], A) -> float(A);
 aband([X|T], A) -> aband(T, checkint32(X) band A).
 
-fbnot(As, St) ->
+fbnot(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[N|_] ->
 	    NotN = bnot checkint32(N),
@@ -70,7 +71,7 @@ fbnot(As, St) ->
 	error -> badarg_error('bnot', As, St)
     end.
 
-fbor(As, St) ->
+fbor(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	L when is_list(L) -> {[abor(L)], St};
 	error -> badarg_error('bor', As, St)
@@ -82,13 +83,13 @@ abor([X|T]) -> abor(T, checkint32(X)).
 abor([], A) -> float(A);
 abor([X|T], A) -> abor(T, checkint32(X) bor A).
 
-fbtest(As, St) ->
+fbtest(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	L when is_list(L) -> {[aband(L) /= 0], St};
 	error -> badarg_error('btest', As, St)
     end.
 
-fbxor(As, St) ->
+fbxor(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	L when is_list(L) -> {[abxor(L)], St};
 	error -> badarg_error('bxor', As, St)
@@ -100,19 +101,19 @@ abxor([X|T]) -> abxor(T, checkint32(X)).
 abxor([], A) -> float(A);
 abxor([X|T], A) -> abxor(T, checkint32(X) bxor A).
 
-flshift(As, St) ->
+flshift(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[X,Y|_] -> {[float(checkint32(X) bsl trunc(Y))], St};
 	_ -> badarg_error('lshift', As, St)
     end.
 
-frshift(As, St) ->
+frshift(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[X,Y|_] -> {[float(checkint32(X) bsr trunc(Y))], St};
 	_ -> badarg_error('rshift', As, St)
     end.
 
-farshift(As, St) ->
+farshift(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[X,Y|_] ->
 	    Disp = trunc(Y),
@@ -123,19 +124,19 @@ farshift(As, St) ->
 	_ -> badarg_error('arshift', As, St)
     end.
 
-flrotate(As, St) ->
+flrotate(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[X,Y|_] -> {[float(lrotate(checkint32(X), trunc(Y)))], St};
 	_ -> badarg_error('lrotate', As, St)
     end.
 
-frrotate(As, St) ->
+frrotate(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[X,Y|_] -> {[float(rrotate(checkint32(X), trunc(Y)))], St};
 	_ -> badarg_error('rrotate', As, St)
     end.
 
-fextract(As, St) ->
+fextract(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[N,Field,Width|_] ->
 	    {[float(extract(N, Field, Width, As, St))], St};
@@ -144,7 +145,7 @@ fextract(As, St) ->
 	_ -> badarg_error('extract', As, St)
     end.
 
-freplace(As, St) ->
+freplace(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	[N,V,Field,Width|_] ->
 	    {[float(replace(N, V, Field, Width, As, St))], St};

--- a/src/luerl_lib_bit32.erl
+++ b/src/luerl_lib_bit32.erl
@@ -37,18 +37,18 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"band">>,#erl_mfa{m=luerl_lib_bit32,f=fband}},
-     {<<"bnot">>,#erl_mfa{m=luerl_lib_bit32,f=fbnot}},
-     {<<"bor">>,#erl_mfa{m=luerl_lib_bit32,f=fbor}},
-     {<<"btest">>,#erl_mfa{m=luerl_lib_bit32,f=fbtest}},
-     {<<"bxor">>,#erl_mfa{m=luerl_lib_bit32,f=fbxor}},
-     {<<"lshift">>,#erl_mfa{m=luerl_lib_bit32,f=flshift}},
-     {<<"rshift">>,#erl_mfa{m=luerl_lib_bit32,f=frshift}},
-     {<<"arshift">>,#erl_mfa{m=luerl_lib_bit32,f=farshift}},
-     {<<"lrotate">>,#erl_mfa{m=luerl_lib_bit32,f=flrotate}},
-     {<<"rrotate">>,#erl_mfa{m=luerl_lib_bit32,f=frrotate}},
-     {<<"extract">>,#erl_mfa{m=luerl_lib_bit32,f=fextract}},
-     {<<"replace">>,#erl_mfa{m=luerl_lib_bit32,f=freplace}}
+    [{<<"band">>,#erl_mfa{m=?MODULE,f=fband}},
+     {<<"bnot">>,#erl_mfa{m=?MODULE,f=fbnot}},
+     {<<"bor">>,#erl_mfa{m=?MODULE,f=fbor}},
+     {<<"btest">>,#erl_mfa{m=?MODULE,f=fbtest}},
+     {<<"bxor">>,#erl_mfa{m=?MODULE,f=fbxor}},
+     {<<"lshift">>,#erl_mfa{m=?MODULE,f=flshift}},
+     {<<"rshift">>,#erl_mfa{m=?MODULE,f=frshift}},
+     {<<"arshift">>,#erl_mfa{m=?MODULE,f=farshift}},
+     {<<"lrotate">>,#erl_mfa{m=?MODULE,f=flrotate}},
+     {<<"rrotate">>,#erl_mfa{m=?MODULE,f=frrotate}},
+     {<<"extract">>,#erl_mfa{m=?MODULE,f=fextract}},
+     {<<"replace">>,#erl_mfa{m=?MODULE,f=freplace}}
      ].
 
 fband(_, As, St) ->

--- a/src/luerl_lib_bit32.erl
+++ b/src/luerl_lib_bit32.erl
@@ -37,18 +37,18 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"band">>,#erl_mfa{m=luerl_lib_bit32,f=fband,a=nil}},
-     {<<"bnot">>,#erl_mfa{m=luerl_lib_bit32,f=fbnot,a=nil}},
-     {<<"bor">>,#erl_mfa{m=luerl_lib_bit32,f=fbor,a=nil}},
-     {<<"btest">>,#erl_mfa{m=luerl_lib_bit32,f=fbtest,a=nil}},
-     {<<"bxor">>,#erl_mfa{m=luerl_lib_bit32,f=fbxor,a=nil}},
-     {<<"lshift">>,#erl_mfa{m=luerl_lib_bit32,f=flshift,a=nil}},
-     {<<"rshift">>,#erl_mfa{m=luerl_lib_bit32,f=frshift,a=nil}},
-     {<<"arshift">>,#erl_mfa{m=luerl_lib_bit32,f=farshift,a=nil}},
-     {<<"lrotate">>,#erl_mfa{m=luerl_lib_bit32,f=flrotate,a=nil}},
-     {<<"rrotate">>,#erl_mfa{m=luerl_lib_bit32,f=frrotate,a=nil}},
-     {<<"extract">>,#erl_mfa{m=luerl_lib_bit32,f=fextract,a=nil}},
-     {<<"replace">>,#erl_mfa{m=luerl_lib_bit32,f=freplace,a=nil}}
+    [{<<"band">>,#erl_mfa{m=luerl_lib_bit32,f=fband}},
+     {<<"bnot">>,#erl_mfa{m=luerl_lib_bit32,f=fbnot}},
+     {<<"bor">>,#erl_mfa{m=luerl_lib_bit32,f=fbor}},
+     {<<"btest">>,#erl_mfa{m=luerl_lib_bit32,f=fbtest}},
+     {<<"bxor">>,#erl_mfa{m=luerl_lib_bit32,f=fbxor}},
+     {<<"lshift">>,#erl_mfa{m=luerl_lib_bit32,f=flshift}},
+     {<<"rshift">>,#erl_mfa{m=luerl_lib_bit32,f=frshift}},
+     {<<"arshift">>,#erl_mfa{m=luerl_lib_bit32,f=farshift}},
+     {<<"lrotate">>,#erl_mfa{m=luerl_lib_bit32,f=flrotate}},
+     {<<"rrotate">>,#erl_mfa{m=luerl_lib_bit32,f=frrotate}},
+     {<<"extract">>,#erl_mfa{m=luerl_lib_bit32,f=fextract}},
+     {<<"replace">>,#erl_mfa{m=luerl_lib_bit32,f=freplace}}
      ].
 
 fband(_, As, St) ->

--- a/src/luerl_lib_debug.erl
+++ b/src/luerl_lib_debug.erl
@@ -34,10 +34,10 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"getmetatable">>,#erl_mfa{m=luerl_lib_debug,f=getmetatable,a=nil}},
-     {<<"getuservalue">>,#erl_mfa{m=luerl_lib_debug,f=getuservalue,a=nil}},
-     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_debug,f=setmetatable,a=nil}},
-     {<<"setuservalue">>,#erl_mfa{m=luerl_lib_debug,f=setuservalue,a=nil}}
+    [{<<"getmetatable">>,#erl_mfa{m=luerl_lib_debug,f=getmetatable}},
+     {<<"getuservalue">>,#erl_mfa{m=luerl_lib_debug,f=getuservalue}},
+     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_debug,f=setmetatable}},
+     {<<"setuservalue">>,#erl_mfa{m=luerl_lib_debug,f=setuservalue}}
     ].
 
 %% getmetatable([Value|_], State) -> {[Table],State}.

--- a/src/luerl_lib_debug.erl
+++ b/src/luerl_lib_debug.erl
@@ -34,10 +34,10 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"getmetatable">>,#erl_mfa{m=luerl_lib_debug,f=getmetatable}},
-     {<<"getuservalue">>,#erl_mfa{m=luerl_lib_debug,f=getuservalue}},
-     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_debug,f=setmetatable}},
-     {<<"setuservalue">>,#erl_mfa{m=luerl_lib_debug,f=setuservalue}}
+    [{<<"getmetatable">>,#erl_mfa{m=?MODULE,f=getmetatable}},
+     {<<"getuservalue">>,#erl_mfa{m=?MODULE,f=getuservalue}},
+     {<<"setmetatable">>,#erl_mfa{m=?MODULE,f=setmetatable}},
+     {<<"setuservalue">>,#erl_mfa{m=?MODULE,f=setuservalue}}
     ].
 
 %% getmetatable([Value|_], State) -> {[Table],State}.

--- a/src/luerl_lib_debug.erl
+++ b/src/luerl_lib_debug.erl
@@ -24,7 +24,7 @@
 -include("luerl.hrl").
 
 %% The basic entry point to set up the function table.
--export([install/1]).
+-export([install/1,getmetatable/3,getuservalue/3,setmetatable/3,setuservalue/3]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]).       %Shorten this
 
@@ -34,10 +34,10 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"getmetatable">>,#erl_func{code=fun getmetatable/2}},
-     {<<"getuservalue">>,#erl_func{code=fun getuservalue/2}},
-     {<<"setmetatable">>,#erl_func{code=fun setmetatable/2}},
-     {<<"setuservalue">>,#erl_func{code=fun setuservalue/2}}
+    [{<<"getmetatable">>,#erl_mfa{m=luerl_lib_debug,f=getmetatable,a=nil}},
+     {<<"getuservalue">>,#erl_mfa{m=luerl_lib_debug,f=getuservalue,a=nil}},
+     {<<"setmetatable">>,#erl_mfa{m=luerl_lib_debug,f=setmetatable,a=nil}},
+     {<<"setuservalue">>,#erl_mfa{m=luerl_lib_debug,f=setuservalue,a=nil}}
     ].
 
 %% getmetatable([Value|_], State) -> {[Table],State}.
@@ -46,21 +46,21 @@ table() ->
 %%  values, for tables and userdata it is the table of the object,
 %%  else the metatable for the type.
 
-getmetatable([O|_], St) ->
+getmetatable(_, [O|_], St) ->
     {[luerl_heap:get_metatable(O, St)],St};
-getmetatable(As, St) -> badarg_error(getmetatable, As, St).
+getmetatable(_, As, St) -> badarg_error(getmetatable, As, St).
 
-setmetatable([T,M|_], St0) ->
+setmetatable(_, [T,M|_], St0) ->
     St1 = luerl_heap:set_metatable(T, M, St0),
     {[T],St1};
-setmetatable(As, St) -> badarg_error(setmetatable, As, St).
+setmetatable(_, As, St) -> badarg_error(setmetatable, As, St).
 
 %% getuservalue([User|_], State) -> {[Value],State}.
 %% setuservalue([User,Value|_], State) -> {[User],State}.
 %%  These are basically no-ops.
 
-getuservalue([_|_], St) -> {[nil],St};
-getuservalue(As, St) -> badarg_error(getuservalue, As, St).
+getuservalue(_, [_|_], St) -> {[nil],St};
+getuservalue(_, As, St) -> badarg_error(getuservalue, As, St).
 
-setuservalue([U,_|_], St) -> {[U],St};
-setuservalue(As, St) -> badarg_error(setuservalue, As, St).
+setuservalue(_, [U,_|_], St) -> {[U],St};
+setuservalue(_, As, St) -> badarg_error(setuservalue, As, St).

--- a/src/luerl_lib_io.erl
+++ b/src/luerl_lib_io.erl
@@ -32,8 +32,8 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"flush">>,#erl_mfa{m=luerl_lib_io,f=flush,a=nil}},
-     {<<"write">>,#erl_mfa{m=luerl_lib_io,f=write,a=nil}}
+    [{<<"flush">>,#erl_mfa{m=luerl_lib_io,f=flush}},
+     {<<"write">>,#erl_mfa{m=luerl_lib_io,f=write}}
     ].
 
 flush(_, _, St) -> {[true],St}.

--- a/src/luerl_lib_io.erl
+++ b/src/luerl_lib_io.erl
@@ -32,8 +32,8 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"flush">>,#erl_mfa{m=luerl_lib_io,f=flush}},
-     {<<"write">>,#erl_mfa{m=luerl_lib_io,f=write}}
+    [{<<"flush">>,#erl_mfa{m=?MODULE,f=flush}},
+     {<<"write">>,#erl_mfa{m=?MODULE,f=write}}
     ].
 
 flush(_, _, St) -> {[true],St}.

--- a/src/luerl_lib_io.erl
+++ b/src/luerl_lib_io.erl
@@ -22,7 +22,7 @@
 
 -include("luerl.hrl").
 
--export([install/1]).
+-export([install/1,flush/3,write/3]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]).	%Shorten this
 
@@ -32,13 +32,13 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"flush">>,#erl_func{code=fun flush/2}},
-     {<<"write">>,#erl_func{code=fun write/2}}
+    [{<<"flush">>,#erl_mfa{m=luerl_lib_io,f=flush,a=nil}},
+     {<<"write">>,#erl_mfa{m=luerl_lib_io,f=write,a=nil}}
     ].
 
-flush(_, St) -> {[true],St}.
+flush(_, _, St) -> {[true],St}.
 
-write(As, St) ->
+write(_, As, St) ->
     case luerl_lib:args_to_strings(As) of
 	error -> badarg_error(write, As, St);
 	Ss ->

--- a/src/luerl_lib_math.erl
+++ b/src/luerl_lib_math.erl
@@ -32,7 +32,10 @@
          fmod/3,frexp/3,ldexp/3,log/3,log10/3,max/3,min/3,modf/3,pow/3,rad/3,random/3,randomseed/3,
          sin/3,sinh/3,sqrt/3,tan/3,tanh/3,tointeger/3,type/3]).
 
+-export([internalize/1,externalize/1]).
+
 -import(luerl_lib, [lua_error/2,badarg_error/3]).	%Shorten this
+
 
 %% Use the correct random number module.
 
@@ -41,6 +44,8 @@
 -define(RAND_UNIFORM(L, S), rand:uniform_s(L, S)).
 -define(RAND_SEED(), rand:seed_s(exs1024)).
 -define(RAND_SEED(S1,S2,S3), rand:seed_s(exs1024, {S1,S2,S3})).
+-define(RAND_EXTERNALIZE(S), rand_externalize(S)).
+-define(RAND_INTERNALIZE(S), rand_internalize(S)).
 -else.
 -define(RAND_UNIFORM(S), random:uniform_s(S)).
 -define(RAND_UNIFORM(L, S), random:uniform_s(L, S)).
@@ -49,6 +54,8 @@
         {(abs(S1) rem (30269-1) + 1),           %PRIME1
          (abs(S2) rem (30307-1) + 1),           %PRIME2
          (abs(S3) rem (30323-1) + 1)}).         %PRIME3
+-define(RAND_EXTERNALIZE(S), S).                % random has just three integers for state so no special work needed.
+-define(RAND_INTERNALIZE(S), S).
 -endif.
 
 install(St0) ->
@@ -358,3 +365,17 @@ get_number_args(As) ->
 %% 	nil -> []
 %%     end;
 %% get_number_args([]) -> [].
+
+internalize(S) ->
+   ?RAND_INTERNALIZE(S).
+
+externalize(S) ->
+   ?RAND_EXTERNALIZE(S).
+
+-ifdef(NEW_RAND).
+rand_externalize(#luerl{rand=S0}=St) ->
+    St#luerl{rand=rand:export_seed_s(S0)}.
+
+rand_internalize(#luerl{rand=S0}=St) ->
+    St#luerl{rand=rand:seed_s(S0)}.
+-endif.

--- a/src/luerl_lib_math.erl
+++ b/src/luerl_lib_math.erl
@@ -28,7 +28,9 @@
 
 -include("luerl.hrl").
 
--export([install/1,fmod/2,frexp/2]).
+-export([install/1,fmod/3,frexp/3,abs/3,acos/3,asin/3,atan/3,ceil/3,cos/3,deg/3,exp/3,floor/3,
+         fmod/3,frexp/3,ldexp/3,log/3,log10/3,max/3,min/3,modf/3,pow/3,rad/3,random/3,randomseed/3,
+         sin/3,sinh/3,sqrt/3,tan/3,tanh/3,tointeger/3,type/3]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]).	%Shorten this
 
@@ -54,63 +56,63 @@ install(St0) ->
     luerl_heap:alloc_table(table(), St1).
 
 table() ->
-    [{<<"abs">>,#erl_func{code=fun abs/2}},
-     {<<"acos">>,#erl_func{code=fun acos/2}},
-     {<<"asin">>,#erl_func{code=fun asin/2}},
-     {<<"atan">>,#erl_func{code=fun atan/2}},
-     {<<"atan2">>,#erl_func{code=fun atan2/2}}, %For 5.2 backwards compatibility
-     {<<"ceil">>,#erl_func{code=fun ceil/2}},
-     {<<"cos">>,#erl_func{code=fun cos/2}},
-     {<<"cosh">>,#erl_func{code=fun cosh/2}},   %For 5.2 backwards compatibility
-     {<<"deg">>,#erl_func{code=fun deg/2}},
-     {<<"exp">>,#erl_func{code=fun exp/2}},
-     {<<"floor">>,#erl_func{code=fun floor/2}},
-     {<<"fmod">>,#erl_func{code=fun fmod/2}},
-     {<<"frexp">>,#erl_func{code=fun frexp/2}}, %For 5.2 backwards compatibility
+    [{<<"abs">>,#erl_mfa{m=luerl_lib_math,f=abs,a=nil}},
+     {<<"acos">>,#erl_mfa{m=luerl_lib_math,f=acos,a=nil}},
+     {<<"asin">>,#erl_mfa{m=luerl_lib_math,f=asin,a=nil}},
+     {<<"atan">>,#erl_mfa{m=luerl_lib_math,f=atan,a=nil}},
+     {<<"atan2">>,#erl_mfa{m=luerl_lib_math,f=atan2,a=nil}}, %For 5.2 backwards compatibility
+     {<<"ceil">>,#erl_mfa{m=luerl_lib_math,f=ceil,a=nil}},
+     {<<"cos">>,#erl_mfa{m=luerl_lib_math,f=cos,a=nil}},
+     {<<"cosh">>,#erl_mfa{m=luerl_lib_math,f=cosh,a=nil}},   %For 5.2 backwards compatibility
+     {<<"deg">>,#erl_mfa{m=luerl_lib_math,f=deg,a=nil}},
+     {<<"exp">>,#erl_mfa{m=luerl_lib_math,f=exp,a=nil}},
+     {<<"floor">>,#erl_mfa{m=luerl_lib_math,f=floor,a=nil}},
+     {<<"fmod">>,#erl_mfa{m=luerl_lib_math,f=fmod,a=nil}},
+     {<<"frexp">>,#erl_mfa{m=luerl_lib_math,f=frexp,a=nil}}, %For 5.2 backwards compatibility
      {<<"huge">>,1.7976931348623157e308},       %From the specs
-     {<<"ldexp">>,#erl_func{code=fun ldexp/2}}, %For 5.2 backwards compatibility
-     {<<"log">>,#erl_func{code=fun log/2}},
-     {<<"log10">>,#erl_func{code=fun log10/2}}, %For 5.1 backwards compatibility
-     {<<"max">>,#erl_func{code=fun max/2}},
+     {<<"ldexp">>,#erl_mfa{m=luerl_lib_math,f=ldexp,a=nil}}, %For 5.2 backwards compatibility
+     {<<"log">>,#erl_mfa{m=luerl_lib_math,f=log,a=nil}},
+     {<<"log10">>,#erl_mfa{m=luerl_lib_math,f=log10,a=nil}}, %For 5.1 backwards compatibility
+     {<<"max">>,#erl_mfa{m=luerl_lib_math,f=max,a=nil}},
      {<<"maxinteger">>,16#7FFFFFFFFFFFFFFF},    %From Lua 5.4.3
-     {<<"min">>,#erl_func{code=fun min/2}},
+     {<<"min">>,#erl_mfa{m=luerl_lib_math,f=min,a=nil}},
      {<<"mininteger">>,-16#8000000000000000},   %From Lua 5.4.3
-     {<<"modf">>,#erl_func{code=fun modf/2}},
+     {<<"modf">>,#erl_mfa{m=luerl_lib_math,f=modf,a=nil}},
      {<<"pi">>,math:pi()},
-     {<<"pow">>,#erl_func{code=fun pow/2}},
-     {<<"rad">>,#erl_func{code=fun rad/2}},
-     {<<"random">>,#erl_func{code=fun random/2}},
-     {<<"randomseed">>,#erl_func{code=fun randomseed/2}},
-     {<<"sin">>,#erl_func{code=fun sin/2}},
-     {<<"sinh">>,#erl_func{code=fun sinh/2}},   %For 5.2 backwards compatibility
-     {<<"sqrt">>,#erl_func{code=fun sqrt/2}},
-     {<<"tan">>,#erl_func{code=fun tan/2}},
-     {<<"tanh">>,#erl_func{code=fun tanh/2}},   %For 5.2 backwards compatibility
-     {<<"tointeger">>,#erl_func{code=fun tointeger/2}},
-     {<<"type">>,#erl_func{code=fun type/2}}
+     {<<"pow">>,#erl_mfa{m=luerl_lib_math,f=pow,a=nil}},
+     {<<"rad">>,#erl_mfa{m=luerl_lib_math,f=rad,a=nil}},
+     {<<"random">>,#erl_mfa{m=luerl_lib_math,f=random,a=nil}},
+     {<<"randomseed">>,#erl_mfa{m=luerl_lib_math,f=randomseed,a=nil}},
+     {<<"sin">>,#erl_mfa{m=luerl_lib_math,f=sin,a=nil}},
+     {<<"sinh">>,#erl_mfa{m=luerl_lib_math,f=sinh,a=nil}},   %For 5.2 backwards compatibility
+     {<<"sqrt">>,#erl_mfa{m=luerl_lib_math,f=sqrt,a=nil}},
+     {<<"tan">>,#erl_mfa{m=luerl_lib_math,f=tan,a=nil}},
+     {<<"tanh">>,#erl_mfa{m=luerl_lib_math,f=tanh,a=nil}},   %For 5.2 backwards compatibility
+     {<<"tointeger">>,#erl_mfa{m=luerl_lib_math,f=tointeger,a=nil}},
+     {<<"type">>,#erl_mfa{m=luerl_lib_math,f=type,a=nil}}
     ].
 
 %% abs(Args, State) -> {[Ret],State}.
 
-abs(As, St) ->
+abs(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[abs(N)],St};
 	_ -> badarg_error(abs, As, St)
     end.
 
-acos(As, St) ->
+acos(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:acos(N)],St};
 	_ -> badarg_error(acos, As, St)
     end.
 
-asin(As, St) ->
+asin(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:asin(N)],St};
 	_ -> badarg_error(asin, As, St)
     end.
 
-atan(As, St) ->
+atan(_, As, St) ->
     case get_number_args(As) of
 	[N1,N2|_] when is_number(N1), is_number(N2) ->
 	    {[math:atan2(N1, N2)],St};
@@ -118,14 +120,14 @@ atan(As, St) ->
 	_ -> badarg_error(atan, As, St)
     end.
 
-atan2(As, St) ->                                %For 5.2 backwards compatibility
+atan2(_, As, St) ->                                %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[N1,N2|_] when is_number(N1), is_number(N2) ->
 	    {[math:atan2(N1, N2)],St};
 	_ -> badarg_error(atan2, As, St)
     end.
 
-ceil(As, St) ->
+ceil(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[ceil(N)],St};
 	_ -> badarg_error(ceil, As, St)
@@ -139,31 +141,31 @@ ceil(N) when is_integer(N) -> N;
 ceil(N) when is_float(N) -> round(N + 0.5).
 -endif.
 
-cos(As, St) ->
+cos(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:cos(N)],St};
 	_ -> badarg_error(cos, As, St)
     end.
 
-cosh(As, St) ->                                 %For 5.2 backwards compatibility
+cosh(_, As, St) ->                                 %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:cosh(N)],St};
 	_ -> badarg_error(cosh, As, St)
     end.
 
-deg(As, St) ->
+deg(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[180.0*N/math:pi()],St};
 	_ -> badarg_error(deg, As, St)
     end.
 
-exp(As, St) ->
+exp(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:exp(N)],St};
 	_ -> badarg_error(exp, As, St)
     end.
 
-floor(As, St) ->
+floor(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[floor(N)],St};
 	_ -> badarg_error(floor, As, St)
@@ -177,7 +179,7 @@ floor(N) when is_integer(N) -> N;
 floor(N) when is_float(N) -> round(N - 0.5).
 -endif.
 
-fmod(As, St) ->
+fmod(_, As, St) ->
     case get_number_args(As) of
 	[X,Y|_] when is_number(X), is_number(Y) ->
 	    Div = trunc(X/Y),
@@ -186,7 +188,7 @@ fmod(As, St) ->
 	_ -> badarg_error(fmod, As, St)
     end.
 
-frexp(As, St) ->                                %For 5.2 backwards compatibility
+frexp(_, As, St) ->                                %For 5.2 backwards compatibility
     %% M,E such that X = M * 2 ^ E.
     case get_number_args(As) of
 	[X|_] when is_number(X)  ->
@@ -206,7 +208,7 @@ frexp(As, St) ->                                %For 5.2 backwards compatibility
 	_ -> badarg_error(frexp, As, St)
     end.
 
-ldexp(As, St) ->                                %For 5.2 backwards compatibility
+ldexp(_, As, St) ->                                %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[M,E|_] when is_float(M), is_integer(E) ->
 	    {[M*math:pow(2, E)],St};
@@ -215,7 +217,7 @@ ldexp(As, St) ->                                %For 5.2 backwards compatibility
 	_ -> badarg_error(ldexp, As, St)
     end.
 
-log(As, St) ->
+log(_, As, St) ->
     case get_number_args(As) of
 	[N1,N2|_] when is_number(N1), N2 == 10 ->
 	    {[math:log10(N1)],St};		%Seeing it is builtin
@@ -226,7 +228,7 @@ log(As, St) ->
 	_ -> badarg_error(log, As, St)
     end.
 
-log10(As, St) ->				%For 5.1 backwards compatibility
+log10(_, As, St) ->				%For 5.1 backwards compatibility
     case get_number_args(As) of
 	[N|_] when N == 0 -> {[-500.0],St};	%Bit hacky
 	[N|_] when is_number(N) ->
@@ -234,19 +236,19 @@ log10(As, St) ->				%For 5.1 backwards compatibility
 	_ -> badarg_error(log10, As, St)
     end.
 
-max(As, St) ->
+max(_, As, St) ->
     case luerl_lib:args_to_numbers(As) of
 	[_|_]=Ns -> {[lists:max(Ns)],St};	%At least one number
 	_ -> badarg_error(max, As, St)
     end.
 
-min(As, St) ->
+min(_, As, St) ->
     case luerl_lib:args_to_numbers(As) of
 	[_|_]=Ns -> {[lists:min(Ns)],St};	%At least one number
 	_ -> badarg_error(min, As, St)
     end.
 
-modf(As, St) ->
+modf(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_integer(N) -> {[N,0.0],St};
 	[N|_] when is_float(N) ->
@@ -255,20 +257,20 @@ modf(As, St) ->
 	_ -> badarg_error(modf, As, St)
     end.
 
-pow(As, St) ->                                  %For 5.2 backwards compatibility
+pow(_, As, St) ->                                  %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[N1,N2|_] when is_number(N1) and is_number(N2) ->
 	    {[math:pow(N1, N2)],St};
 	_ -> badarg_error(pow, As, St)
     end.
 
-rad(As, St) ->
+rad(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:pi()*N/180.0],St};
 	_ -> badarg_error(rad, As, St)
     end.
 
-random(As, #luerl{rand=S0}=St) ->
+random(_, As, #luerl{rand=S0}=St) ->
     case luerl_lib:args_to_integers(As) of
 	[] ->					%0.0 - 1.0
 	    {R,S1} = ?RAND_UNIFORM(S0),
@@ -282,7 +284,7 @@ random(As, #luerl{rand=S0}=St) ->
 	_ -> badarg_error(random, As, St)
     end.
 
-randomseed(As, St) ->
+randomseed(_, As, St) ->
     case get_number_args(As) of
 	[S|_] when is_number(S) ->
 	    %% Split integer or float-64 into three integers.
@@ -291,37 +293,37 @@ randomseed(As, St) ->
 	_ -> badarg_error(randomseed, As, St)
     end.
 
-sin(As, St) ->
+sin(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:sin(N)],St};
 	_ -> badarg_error(sin, As, St)
     end.
 
-sinh(As, St) ->                                 %For 5.2 backwards compatibility
+sinh(_, As, St) ->                                 %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:sinh(N)],St};
 	_ -> badarg_error(sinh, As, St)
     end.
 
-sqrt(As, St) ->
+sqrt(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:sqrt(N)],St};
 	_ -> badarg_error(sqrt, As, St)
     end.
 
-tan(As, St) ->
+tan(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:tan(N)],St};
 	_ -> badarg_error(tan, As, St)
     end.
 
-tanh(As, St) ->                                 %For 5.2 backwards compatibility
+tanh(_, As, St) ->                                 %For 5.2 backwards compatibility
     case get_number_args(As) of
 	[N|_] when is_number(N) -> {[math:tanh(N)],St};
 	_ -> badarg_error(tanh, As, St)
     end.
 
-tointeger(As, St) ->
+tointeger(_, As, St) ->
     case get_number_args(As) of
 	[N|_] when is_integer(N) -> {[N],St};
 	[N|_] when is_float(N) ->
@@ -333,7 +335,7 @@ tointeger(As, St) ->
 	[] -> badarg_error(tointeger, As, St)
     end.
 
-type(As, St) ->
+type(_, As, St) ->
     %% No conversion here.
     case As of
 	[N|_] when is_integer(N) -> {[<<"integer">>],St};

--- a/src/luerl_lib_math.erl
+++ b/src/luerl_lib_math.erl
@@ -56,40 +56,40 @@ install(St0) ->
     luerl_heap:alloc_table(table(), St1).
 
 table() ->
-    [{<<"abs">>,#erl_mfa{m=luerl_lib_math,f=abs}},
-     {<<"acos">>,#erl_mfa{m=luerl_lib_math,f=acos}},
-     {<<"asin">>,#erl_mfa{m=luerl_lib_math,f=asin}},
-     {<<"atan">>,#erl_mfa{m=luerl_lib_math,f=atan}},
-     {<<"atan2">>,#erl_mfa{m=luerl_lib_math,f=atan2}}, %For 5.2 backwards compatibility
-     {<<"ceil">>,#erl_mfa{m=luerl_lib_math,f=ceil}},
-     {<<"cos">>,#erl_mfa{m=luerl_lib_math,f=cos}},
-     {<<"cosh">>,#erl_mfa{m=luerl_lib_math,f=cosh}},   %For 5.2 backwards compatibility
-     {<<"deg">>,#erl_mfa{m=luerl_lib_math,f=deg}},
-     {<<"exp">>,#erl_mfa{m=luerl_lib_math,f=exp}},
-     {<<"floor">>,#erl_mfa{m=luerl_lib_math,f=floor}},
-     {<<"fmod">>,#erl_mfa{m=luerl_lib_math,f=fmod}},
-     {<<"frexp">>,#erl_mfa{m=luerl_lib_math,f=frexp}}, %For 5.2 backwards compatibility
+    [{<<"abs">>,#erl_mfa{m=?MODULE,f=abs}},
+     {<<"acos">>,#erl_mfa{m=?MODULE,f=acos}},
+     {<<"asin">>,#erl_mfa{m=?MODULE,f=asin}},
+     {<<"atan">>,#erl_mfa{m=?MODULE,f=atan}},
+     {<<"atan2">>,#erl_mfa{m=?MODULE,f=atan2}}, %For 5.2 backwards compatibility
+     {<<"ceil">>,#erl_mfa{m=?MODULE,f=ceil}},
+     {<<"cos">>,#erl_mfa{m=?MODULE,f=cos}},
+     {<<"cosh">>,#erl_mfa{m=?MODULE,f=cosh}},   %For 5.2 backwards compatibility
+     {<<"deg">>,#erl_mfa{m=?MODULE,f=deg}},
+     {<<"exp">>,#erl_mfa{m=?MODULE,f=exp}},
+     {<<"floor">>,#erl_mfa{m=?MODULE,f=floor}},
+     {<<"fmod">>,#erl_mfa{m=?MODULE,f=fmod}},
+     {<<"frexp">>,#erl_mfa{m=?MODULE,f=frexp}}, %For 5.2 backwards compatibility
      {<<"huge">>,1.7976931348623157e308},       %From the specs
-     {<<"ldexp">>,#erl_mfa{m=luerl_lib_math,f=ldexp}}, %For 5.2 backwards compatibility
-     {<<"log">>,#erl_mfa{m=luerl_lib_math,f=log}},
-     {<<"log10">>,#erl_mfa{m=luerl_lib_math,f=log10}}, %For 5.1 backwards compatibility
-     {<<"max">>,#erl_mfa{m=luerl_lib_math,f=max}},
+     {<<"ldexp">>,#erl_mfa{m=?MODULE,f=ldexp}}, %For 5.2 backwards compatibility
+     {<<"log">>,#erl_mfa{m=?MODULE,f=log}},
+     {<<"log10">>,#erl_mfa{m=?MODULE,f=log10}}, %For 5.1 backwards compatibility
+     {<<"max">>,#erl_mfa{m=?MODULE,f=max}},
      {<<"maxinteger">>,16#7FFFFFFFFFFFFFFF},    %From Lua 5.4.3
-     {<<"min">>,#erl_mfa{m=luerl_lib_math,f=min}},
+     {<<"min">>,#erl_mfa{m=?MODULE,f=min}},
      {<<"mininteger">>,-16#8000000000000000},   %From Lua 5.4.3
-     {<<"modf">>,#erl_mfa{m=luerl_lib_math,f=modf}},
+     {<<"modf">>,#erl_mfa{m=?MODULE,f=modf}},
      {<<"pi">>,math:pi()},
-     {<<"pow">>,#erl_mfa{m=luerl_lib_math,f=pow}},
-     {<<"rad">>,#erl_mfa{m=luerl_lib_math,f=rad}},
-     {<<"random">>,#erl_mfa{m=luerl_lib_math,f=random}},
-     {<<"randomseed">>,#erl_mfa{m=luerl_lib_math,f=randomseed}},
-     {<<"sin">>,#erl_mfa{m=luerl_lib_math,f=sin}},
-     {<<"sinh">>,#erl_mfa{m=luerl_lib_math,f=sinh}},   %For 5.2 backwards compatibility
-     {<<"sqrt">>,#erl_mfa{m=luerl_lib_math,f=sqrt}},
-     {<<"tan">>,#erl_mfa{m=luerl_lib_math,f=tan}},
-     {<<"tanh">>,#erl_mfa{m=luerl_lib_math,f=tanh}},   %For 5.2 backwards compatibility
-     {<<"tointeger">>,#erl_mfa{m=luerl_lib_math,f=tointeger}},
-     {<<"type">>,#erl_mfa{m=luerl_lib_math,f=type}}
+     {<<"pow">>,#erl_mfa{m=?MODULE,f=pow}},
+     {<<"rad">>,#erl_mfa{m=?MODULE,f=rad}},
+     {<<"random">>,#erl_mfa{m=?MODULE,f=random}},
+     {<<"randomseed">>,#erl_mfa{m=?MODULE,f=randomseed}},
+     {<<"sin">>,#erl_mfa{m=?MODULE,f=sin}},
+     {<<"sinh">>,#erl_mfa{m=?MODULE,f=sinh}},   %For 5.2 backwards compatibility
+     {<<"sqrt">>,#erl_mfa{m=?MODULE,f=sqrt}},
+     {<<"tan">>,#erl_mfa{m=?MODULE,f=tan}},
+     {<<"tanh">>,#erl_mfa{m=?MODULE,f=tanh}},   %For 5.2 backwards compatibility
+     {<<"tointeger">>,#erl_mfa{m=?MODULE,f=tointeger}},
+     {<<"type">>,#erl_mfa{m=?MODULE,f=type}}
     ].
 
 %% abs(Args, State) -> {[Ret],State}.

--- a/src/luerl_lib_math.erl
+++ b/src/luerl_lib_math.erl
@@ -28,7 +28,7 @@
 
 -include("luerl.hrl").
 
--export([install/1,fmod/3,frexp/3,abs/3,acos/3,asin/3,atan/3,ceil/3,cos/3,deg/3,exp/3,floor/3,
+-export([install/1,abs/3,acos/3,asin/3,atan2/3,atan/3,ceil/3,cos/3,cosh/3,deg/3,exp/3,floor/3,
          fmod/3,frexp/3,ldexp/3,log/3,log10/3,max/3,min/3,modf/3,pow/3,rad/3,random/3,randomseed/3,
          sin/3,sinh/3,sqrt/3,tan/3,tanh/3,tointeger/3,type/3]).
 
@@ -56,40 +56,40 @@ install(St0) ->
     luerl_heap:alloc_table(table(), St1).
 
 table() ->
-    [{<<"abs">>,#erl_mfa{m=luerl_lib_math,f=abs,a=nil}},
-     {<<"acos">>,#erl_mfa{m=luerl_lib_math,f=acos,a=nil}},
-     {<<"asin">>,#erl_mfa{m=luerl_lib_math,f=asin,a=nil}},
-     {<<"atan">>,#erl_mfa{m=luerl_lib_math,f=atan,a=nil}},
-     {<<"atan2">>,#erl_mfa{m=luerl_lib_math,f=atan2,a=nil}}, %For 5.2 backwards compatibility
-     {<<"ceil">>,#erl_mfa{m=luerl_lib_math,f=ceil,a=nil}},
-     {<<"cos">>,#erl_mfa{m=luerl_lib_math,f=cos,a=nil}},
-     {<<"cosh">>,#erl_mfa{m=luerl_lib_math,f=cosh,a=nil}},   %For 5.2 backwards compatibility
-     {<<"deg">>,#erl_mfa{m=luerl_lib_math,f=deg,a=nil}},
-     {<<"exp">>,#erl_mfa{m=luerl_lib_math,f=exp,a=nil}},
-     {<<"floor">>,#erl_mfa{m=luerl_lib_math,f=floor,a=nil}},
-     {<<"fmod">>,#erl_mfa{m=luerl_lib_math,f=fmod,a=nil}},
-     {<<"frexp">>,#erl_mfa{m=luerl_lib_math,f=frexp,a=nil}}, %For 5.2 backwards compatibility
+    [{<<"abs">>,#erl_mfa{m=luerl_lib_math,f=abs}},
+     {<<"acos">>,#erl_mfa{m=luerl_lib_math,f=acos}},
+     {<<"asin">>,#erl_mfa{m=luerl_lib_math,f=asin}},
+     {<<"atan">>,#erl_mfa{m=luerl_lib_math,f=atan}},
+     {<<"atan2">>,#erl_mfa{m=luerl_lib_math,f=atan2}}, %For 5.2 backwards compatibility
+     {<<"ceil">>,#erl_mfa{m=luerl_lib_math,f=ceil}},
+     {<<"cos">>,#erl_mfa{m=luerl_lib_math,f=cos}},
+     {<<"cosh">>,#erl_mfa{m=luerl_lib_math,f=cosh}},   %For 5.2 backwards compatibility
+     {<<"deg">>,#erl_mfa{m=luerl_lib_math,f=deg}},
+     {<<"exp">>,#erl_mfa{m=luerl_lib_math,f=exp}},
+     {<<"floor">>,#erl_mfa{m=luerl_lib_math,f=floor}},
+     {<<"fmod">>,#erl_mfa{m=luerl_lib_math,f=fmod}},
+     {<<"frexp">>,#erl_mfa{m=luerl_lib_math,f=frexp}}, %For 5.2 backwards compatibility
      {<<"huge">>,1.7976931348623157e308},       %From the specs
-     {<<"ldexp">>,#erl_mfa{m=luerl_lib_math,f=ldexp,a=nil}}, %For 5.2 backwards compatibility
-     {<<"log">>,#erl_mfa{m=luerl_lib_math,f=log,a=nil}},
-     {<<"log10">>,#erl_mfa{m=luerl_lib_math,f=log10,a=nil}}, %For 5.1 backwards compatibility
-     {<<"max">>,#erl_mfa{m=luerl_lib_math,f=max,a=nil}},
+     {<<"ldexp">>,#erl_mfa{m=luerl_lib_math,f=ldexp}}, %For 5.2 backwards compatibility
+     {<<"log">>,#erl_mfa{m=luerl_lib_math,f=log}},
+     {<<"log10">>,#erl_mfa{m=luerl_lib_math,f=log10}}, %For 5.1 backwards compatibility
+     {<<"max">>,#erl_mfa{m=luerl_lib_math,f=max}},
      {<<"maxinteger">>,16#7FFFFFFFFFFFFFFF},    %From Lua 5.4.3
-     {<<"min">>,#erl_mfa{m=luerl_lib_math,f=min,a=nil}},
+     {<<"min">>,#erl_mfa{m=luerl_lib_math,f=min}},
      {<<"mininteger">>,-16#8000000000000000},   %From Lua 5.4.3
-     {<<"modf">>,#erl_mfa{m=luerl_lib_math,f=modf,a=nil}},
+     {<<"modf">>,#erl_mfa{m=luerl_lib_math,f=modf}},
      {<<"pi">>,math:pi()},
-     {<<"pow">>,#erl_mfa{m=luerl_lib_math,f=pow,a=nil}},
-     {<<"rad">>,#erl_mfa{m=luerl_lib_math,f=rad,a=nil}},
-     {<<"random">>,#erl_mfa{m=luerl_lib_math,f=random,a=nil}},
-     {<<"randomseed">>,#erl_mfa{m=luerl_lib_math,f=randomseed,a=nil}},
-     {<<"sin">>,#erl_mfa{m=luerl_lib_math,f=sin,a=nil}},
-     {<<"sinh">>,#erl_mfa{m=luerl_lib_math,f=sinh,a=nil}},   %For 5.2 backwards compatibility
-     {<<"sqrt">>,#erl_mfa{m=luerl_lib_math,f=sqrt,a=nil}},
-     {<<"tan">>,#erl_mfa{m=luerl_lib_math,f=tan,a=nil}},
-     {<<"tanh">>,#erl_mfa{m=luerl_lib_math,f=tanh,a=nil}},   %For 5.2 backwards compatibility
-     {<<"tointeger">>,#erl_mfa{m=luerl_lib_math,f=tointeger,a=nil}},
-     {<<"type">>,#erl_mfa{m=luerl_lib_math,f=type,a=nil}}
+     {<<"pow">>,#erl_mfa{m=luerl_lib_math,f=pow}},
+     {<<"rad">>,#erl_mfa{m=luerl_lib_math,f=rad}},
+     {<<"random">>,#erl_mfa{m=luerl_lib_math,f=random}},
+     {<<"randomseed">>,#erl_mfa{m=luerl_lib_math,f=randomseed}},
+     {<<"sin">>,#erl_mfa{m=luerl_lib_math,f=sin}},
+     {<<"sinh">>,#erl_mfa{m=luerl_lib_math,f=sinh}},   %For 5.2 backwards compatibility
+     {<<"sqrt">>,#erl_mfa{m=luerl_lib_math,f=sqrt}},
+     {<<"tan">>,#erl_mfa{m=luerl_lib_math,f=tan}},
+     {<<"tanh">>,#erl_mfa{m=luerl_lib_math,f=tanh}},   %For 5.2 backwards compatibility
+     {<<"tointeger">>,#erl_mfa{m=luerl_lib_math,f=tointeger}},
+     {<<"type">>,#erl_mfa{m=luerl_lib_math,f=type}}
     ].
 
 %% abs(Args, State) -> {[Ret],State}.

--- a/src/luerl_lib_os.erl
+++ b/src/luerl_lib_os.erl
@@ -35,16 +35,16 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"clock">>,#erl_mfa{m=luerl_lib_os,f=clock,a=nil}},
-     {<<"date">>,#erl_mfa{m=luerl_lib_os,f=date,a=nil}},
-     {<<"difftime">>,#erl_mfa{m=luerl_lib_os,f=difftime,a=nil}},
-     {<<"execute">>,#erl_mfa{m=luerl_lib_os,f=execute,a=nil}},
-     {<<"exit">>,#erl_mfa{m=luerl_lib_os,f=lua_exit,a=nil}},
-     {<<"getenv">>,#erl_mfa{m=luerl_lib_os,f=getenv,a=nil}},
-     {<<"remove">>,#erl_mfa{m=luerl_lib_os,f=remove,a=nil}},
-     {<<"rename">>,#erl_mfa{m=luerl_lib_os,f=rename,a=nil}},
-     {<<"time">>,#erl_mfa{m=luerl_lib_os,f=time,a=nil}},
-     {<<"tmpname">>,#erl_mfa{m=luerl_lib_os,f=tmpname,a=nil}}].
+    [{<<"clock">>,#erl_mfa{m=luerl_lib_os,f=clock}},
+     {<<"date">>,#erl_mfa{m=luerl_lib_os,f=date}},
+     {<<"difftime">>,#erl_mfa{m=luerl_lib_os,f=difftime}},
+     {<<"execute">>,#erl_mfa{m=luerl_lib_os,f=execute}},
+     {<<"exit">>,#erl_mfa{m=luerl_lib_os,f=lua_exit}},
+     {<<"getenv">>,#erl_mfa{m=luerl_lib_os,f=getenv}},
+     {<<"remove">>,#erl_mfa{m=luerl_lib_os,f=remove}},
+     {<<"rename">>,#erl_mfa{m=luerl_lib_os,f=rename}},
+     {<<"time">>,#erl_mfa{m=luerl_lib_os,f=time}},
+     {<<"tmpname">>,#erl_mfa{m=luerl_lib_os,f=tmpname}}].
 
 getenv(_, [<<>>|_], St) -> {[nil],St};
 getenv(_, [A|_], St) when is_binary(A) ; is_number(A) ->

--- a/src/luerl_lib_os.erl
+++ b/src/luerl_lib_os.erl
@@ -20,7 +20,7 @@
 
 -include("luerl.hrl").
 
--export([install/1]).
+-export([install/1, clock/3, date/3, difftime/3, execute/3, lua_exit/3, getenv/3, remove/3, rename/3, time/3, tmpname/3]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]).       %Shorten this
 
@@ -35,32 +35,32 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"clock">>,#erl_func{code=fun clock/2}},
-     {<<"date">>,#erl_func{code=fun date/2}},
-     {<<"difftime">>,#erl_func{code=fun difftime/2}},
-     {<<"execute">>,#erl_func{code=fun execute/2}},
-     {<<"exit">>,#erl_func{code=fun lua_exit/2}},
-     {<<"getenv">>,#erl_func{code=fun getenv/2}},
-     {<<"remove">>,#erl_func{code=fun remove/2}},
-     {<<"rename">>,#erl_func{code=fun rename/2}},
-     {<<"time">>,#erl_func{code=fun time/2}},
-     {<<"tmpname">>,#erl_func{code=fun tmpname/2}}].
+    [{<<"clock">>,#erl_mfa{m=luerl_lib_os,f=clock,a=nil}},
+     {<<"date">>,#erl_mfa{m=luerl_lib_os,f=date,a=nil}},
+     {<<"difftime">>,#erl_mfa{m=luerl_lib_os,f=difftime,a=nil}},
+     {<<"execute">>,#erl_mfa{m=luerl_lib_os,f=execute,a=nil}},
+     {<<"exit">>,#erl_mfa{m=luerl_lib_os,f=lua_exit,a=nil}},
+     {<<"getenv">>,#erl_mfa{m=luerl_lib_os,f=getenv,a=nil}},
+     {<<"remove">>,#erl_mfa{m=luerl_lib_os,f=remove,a=nil}},
+     {<<"rename">>,#erl_mfa{m=luerl_lib_os,f=rename,a=nil}},
+     {<<"time">>,#erl_mfa{m=luerl_lib_os,f=time,a=nil}},
+     {<<"tmpname">>,#erl_mfa{m=luerl_lib_os,f=tmpname,a=nil}}].
 
-getenv([<<>>|_], St) -> {[nil],St};
-getenv([A|_], St) when is_binary(A) ; is_number(A) ->
+getenv(_, [<<>>|_], St) -> {[nil],St};
+getenv(_, [A|_], St) when is_binary(A) ; is_number(A) ->
     case os:getenv(luerl_lib:arg_to_list(A)) of
         Env when is_list(Env) ->
             {[list_to_binary(Env)],St};
         false -> {[nil],St}
     end;
-getenv(As, St) -> badarg_error(getenv, As, St).
+getenv(_, As, St) -> badarg_error(getenv, As, St).
 
 %% execute([Command|_], State) -> {[Ret,Type,Stat],State}.
 %%  Execute a command and get the return code. We cannot yet properly
 %%  handle if our command terminated with a signal.
 
-execute([], St) -> {true,St};                   %We have a shell
-execute([A|_], St) ->
+execute(_, [], St) -> {true,St};                   %We have a shell
+execute(_, [A|_], St) ->
     case luerl_lib:arg_to_string(A) of
         S when is_binary(S) ->
             Opts = [{arg0,"sh"},{args,["-c", S]},
@@ -73,7 +73,7 @@ execute([A|_], St) ->
             {[Ret,<<"exit">>,N],St};
         error -> badarg_error(execute, [A], St)
     end;
-execute(As, St) -> badarg_error(execute, As, St).
+execute(_, As, St) -> badarg_error(execute, As, St).
 
 execute_handle(P) ->
     receive
@@ -97,11 +97,11 @@ execute_handle(P) ->
 %% NOT IMPLEMENTED:
 %%  If the optional second argument CloseState is true, it will close the Lua
 %%  state before exiting.
-lua_exit([], St) ->
-    lua_exit([true,false], St);
-lua_exit([C], St) ->
-    lua_exit([C,false], St);
-lua_exit([Co0|_], St) -> %% lua_exit([Co0,Cl0], St) ->
+lua_exit(_, [], St) ->
+    lua_exit(nil, [true,false], St);
+lua_exit(_, [C], St) ->
+    lua_exit(nil, [C,false], St);
+lua_exit(_, [Co0|_], St) -> %% lua_exit([Co0,Cl0], St) ->
     Co1 = case luerl_lib:arg_to_number(Co0) of
               X when is_integer(X) -> X;
               error ->
@@ -124,10 +124,10 @@ lua_exit([Co0|_], St) -> %% lua_exit([Co0,Cl0], St) ->
 
 %% tmpname([], State)
 %% Faithfully recreates `tmpnam'(3) in lack of a NIF.
-tmpname([_|_], St) ->
+tmpname(_, [_|_], St) ->
     %% Discard extra arguments.
-    tmpname([], St);
-tmpname([], St) ->
+    tmpname(nil, [], St);
+tmpname(_, [], St) ->
     Out = tmpname_try(randchar(6, []), 0),
     %% We make an empty file the programmer will have to close themselves.
     %% This is done for security reasons.
@@ -153,7 +153,7 @@ randchar(N, A) -> randchar(N-1, [rand:uniform(26)+96|A]).
 %%  Renames the file or directory `Source' to `Destination'. If this function
 %%  fails, it returns `nil', plus a string describing the error code and the
 %%  error code. Otherwise, it returns `true'.
-rename([S,D|_], St) ->
+rename(_, [S,D|_], St) ->
     case {luerl_lib:arg_to_string(S),
           luerl_lib:arg_to_string(D)} of
         {S1,D1} when is_binary(S1) ,
@@ -177,13 +177,13 @@ rename([S,D|_], St) ->
                      not is_binary(D1) ->
             badarg_error(rename, [D1], St)
     end;
-rename(As, St) -> badarg_error(rename, As, St).
+rename(_, As, St) -> badarg_error(rename, As, St).
 
 %% remove([Path|_], State)
 %%  Deletes the file (or empty directory) with the given `Path'. If this
 %%  function fails, it returns `nil' plus a string describing the error, and the
 %%  error code. Otherwise, it returns `true'.
-remove([A|_], St) ->
+remove(_, [A|_], St) ->
     case luerl_lib:arg_to_string(A) of
         A1 when is_binary(A1) ->
             %% Emulate the underlying call to `remove(3)'.
@@ -205,7 +205,7 @@ remove([A|_], St) ->
             end;
         error -> badarg_error(remove, [A], St)
     end;
-remove(As, St) -> badarg_error(remove, As, St).
+remove(_, As, St) -> badarg_error(remove, As, St).
 
 
 %% Utility function to get a preformatted list to return from `remove/2'.
@@ -217,7 +217,7 @@ remove_geterr(R, F) ->
 
 %% Time and date functions.
 
-clock(As, St) ->
+clock(_, As, St) ->
     Type = case As of                           %Choose which we want
                [<<"runtime">>|_] -> runtime;
                _ -> wall_clock
@@ -225,17 +225,17 @@ clock(As, St) ->
     {Tot,_} = erlang:statistics(Type),          %Milliseconds
     {[Tot*1.0e-3],St}.
 
-date(_, St) ->
+date(_, _, St) ->
     {{Ye,Mo,Da},{Ho,Mi,Sec}} = calendar:local_time(),
     Str = io_lib:fwrite("~w-~.2.0w-~.2.0w ~.2.0w:~.2.0w:~.2.0w",
                         [Ye,Mo,Da,Ho,Mi,Sec]),
     {[iolist_to_binary(Str)],St}.
 
-difftime([T2,T1|_], St) ->
+difftime(_, [T2,T1|_], St) ->
     {[T2 - T1],St};
-difftime(As, St) -> badarg_error(difftime, As, St).
+difftime(_, As, St) -> badarg_error(difftime, As, St).
 
 
-time(_, St) ->                                  %Time since 1 Jan 1970
+time(_, _, St) ->                                  %Time since 1 Jan 1970
     {Mega,Sec,Micro} = os:timestamp(),
     {[1.0e6*Mega+Sec+Micro*1.0e-6],St}.

--- a/src/luerl_lib_os.erl
+++ b/src/luerl_lib_os.erl
@@ -35,16 +35,16 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"clock">>,#erl_mfa{m=luerl_lib_os,f=clock}},
-     {<<"date">>,#erl_mfa{m=luerl_lib_os,f=date}},
-     {<<"difftime">>,#erl_mfa{m=luerl_lib_os,f=difftime}},
-     {<<"execute">>,#erl_mfa{m=luerl_lib_os,f=execute}},
-     {<<"exit">>,#erl_mfa{m=luerl_lib_os,f=lua_exit}},
-     {<<"getenv">>,#erl_mfa{m=luerl_lib_os,f=getenv}},
-     {<<"remove">>,#erl_mfa{m=luerl_lib_os,f=remove}},
-     {<<"rename">>,#erl_mfa{m=luerl_lib_os,f=rename}},
-     {<<"time">>,#erl_mfa{m=luerl_lib_os,f=time}},
-     {<<"tmpname">>,#erl_mfa{m=luerl_lib_os,f=tmpname}}].
+    [{<<"clock">>,#erl_mfa{m=?MODULE,f=clock}},
+     {<<"date">>,#erl_mfa{m=?MODULE,f=date}},
+     {<<"difftime">>,#erl_mfa{m=?MODULE,f=difftime}},
+     {<<"execute">>,#erl_mfa{m=?MODULE,f=execute}},
+     {<<"exit">>,#erl_mfa{m=?MODULE,f=lua_exit}},
+     {<<"getenv">>,#erl_mfa{m=?MODULE,f=getenv}},
+     {<<"remove">>,#erl_mfa{m=?MODULE,f=remove}},
+     {<<"rename">>,#erl_mfa{m=?MODULE,f=rename}},
+     {<<"time">>,#erl_mfa{m=?MODULE,f=time}},
+     {<<"tmpname">>,#erl_mfa{m=?MODULE,f=tmpname}}].
 
 getenv(_, [<<>>|_], St) -> {[nil],St};
 getenv(_, [A|_], St) when is_binary(A) ; is_number(A) ->

--- a/src/luerl_lib_package.erl
+++ b/src/luerl_lib_package.erl
@@ -37,7 +37,7 @@
 
 install(St0) ->
     St1 = luerl_emul:set_global_key(<<"require">>,
-				    #erl_mfa{m=luerl_lib_package,f=require,a=nil}, St0),
+				    #erl_mfa{m=luerl_lib_package,f=require}, St0),
     {S,St2} = luerl_heap:alloc_table(searchers_table(), St1),
     {L,St3} = luerl_heap:alloc_table(loaded_table(), St2),
     {P,St4} = luerl_heap:alloc_table(preload_table(), St3),
@@ -56,12 +56,12 @@ table(S, L, P) ->
      {<<"preload">>,P},
      {<<"path">>,path()},
      {<<"searchers">>,S},
-     {<<"searchpath">>,#erl_mfa{m=luerl_lib_package,f=searchpath,a=nil}}
+     {<<"searchpath">>,#erl_mfa{m=luerl_lib_package,f=searchpath}}
     ].
 
 searchers_table() ->
-    [{1.0,#erl_mfa{m=luerl_lib_package,f=preload_searcher,a=nil}},
-     {2.0,#erl_mfa{m=luerl_lib_package,f=lua_searcher,a=nil}}].
+    [{1.0,#erl_mfa{m=luerl_lib_package,f=preload_searcher}},
+     {2.0,#erl_mfa{m=luerl_lib_package,f=lua_searcher}}].
 
 preload_table() -> [].
 

--- a/src/luerl_lib_package.erl
+++ b/src/luerl_lib_package.erl
@@ -37,7 +37,7 @@
 
 install(St0) ->
     St1 = luerl_emul:set_global_key(<<"require">>,
-				    #erl_mfa{m=luerl_lib_package,f=require}, St0),
+				    #erl_mfa{m=?MODULE,f=require}, St0),
     {S,St2} = luerl_heap:alloc_table(searchers_table(), St1),
     {L,St3} = luerl_heap:alloc_table(loaded_table(), St2),
     {P,St4} = luerl_heap:alloc_table(preload_table(), St3),
@@ -56,12 +56,12 @@ table(S, L, P) ->
      {<<"preload">>,P},
      {<<"path">>,path()},
      {<<"searchers">>,S},
-     {<<"searchpath">>,#erl_mfa{m=luerl_lib_package,f=searchpath}}
+     {<<"searchpath">>,#erl_mfa{m=?MODULE,f=searchpath}}
     ].
 
 searchers_table() ->
-    [{1.0,#erl_mfa{m=luerl_lib_package,f=preload_searcher}},
-     {2.0,#erl_mfa{m=luerl_lib_package,f=lua_searcher}}].
+    [{1.0,#erl_mfa{m=?MODULE,f=preload_searcher}},
+     {2.0,#erl_mfa{m=?MODULE,f=lua_searcher}}].
 
 preload_table() -> [].
 

--- a/src/luerl_lib_package.erl
+++ b/src/luerl_lib_package.erl
@@ -28,7 +28,7 @@
 -include("luerl.hrl").
 
 %% The basic entry point to set up the function table.
--export([install/1]).
+-export([install/1,require/3,searchpath/3,preload_searcher/3,lua_searcher/3]).
 
 %% Export some functions which can be called from elsewhere.
 -export([search_path/5]).
@@ -37,7 +37,7 @@
 
 install(St0) ->
     St1 = luerl_emul:set_global_key(<<"require">>,
-				    #erl_func{code=fun require/2}, St0),
+				    #erl_mfa{m=luerl_lib_package,f=require,a=nil}, St0),
     {S,St2} = luerl_heap:alloc_table(searchers_table(), St1),
     {L,St3} = luerl_heap:alloc_table(loaded_table(), St2),
     {P,St4} = luerl_heap:alloc_table(preload_table(), St3),
@@ -56,12 +56,12 @@ table(S, L, P) ->
      {<<"preload">>,P},
      {<<"path">>,path()},
      {<<"searchers">>,S},
-     {<<"searchpath">>,#erl_func{code=fun searchpath/2}}
+     {<<"searchpath">>,#erl_mfa{m=luerl_lib_package,f=searchpath,a=nil}}
     ].
 
 searchers_table() ->
-    [{1.0,#erl_func{code=fun preload_searcher/2}},
-     {2.0,#erl_func{code=fun lua_searcher/2}}].
+    [{1.0,#erl_mfa{m=luerl_lib_package,f=preload_searcher,a=nil}},
+     {2.0,#erl_mfa{m=luerl_lib_package,f=lua_searcher,a=nil}}].
 
 preload_table() -> [].
 
@@ -91,7 +91,7 @@ path() ->
 
 %% searchpath(Name, Path [, Sep [, Rep]]) -> [File] | [nil|Files].
 
-searchpath(As, St) ->
+searchpath(_, As, St) ->
     case luerl_lib:conv_list(search_args(As),
 			     [lua_string,lua_string,lua_string,lua_string]) of
 	[N,P,S,R] ->				%Name, path, sep, rep
@@ -126,12 +126,12 @@ search_path_loop(Name, [T|Ts], Tried) ->
 search_path_loop(_, [], Tried) ->		%Couldn't find it
     {error,iolist_to_binary(Tried)}.
 
--spec require([_], _) -> {_,_} | no_return().	%To keep dialyzer quiet
+-spec require(_, [_], _) -> {_,_} | no_return().	%To keep dialyzer quiet
 
 %% require([File|_], State) ->{Value,State}.
 %%  Main require interface.
 
-require(As, St) ->
+require(_, As, St) ->
     case luerl_lib:conv_list(As, [lua_string]) of
 	[Mod] -> do_require(Mod, St);
 	error -> badarg_error(require, As, St)
@@ -183,7 +183,7 @@ search_loaders_loop(Mod, [], Estr, St) ->	%No successful loader found
 %%  Predefined search functions in package.searchers. These must be Lua
 %%  callable functions as they are visible.
 
-preload_searcher(As, St0) ->
+preload_searcher(_, As, St0) ->
     case luerl_lib:conv_list(As, [lua_string]) of
 	[Mod] ->
 	    {Pre,St1} = luerl_emul:get_table_keys([<<"package">>,<<"preload">>],
@@ -195,7 +195,7 @@ preload_searcher(As, St0) ->
 	error -> badarg_error(preload_searcher, As, St0)
     end.
 
-lua_searcher(As, St0) ->
+lua_searcher(_, As, St0) ->
     case luerl_lib:conv_list(As, [lua_string]) of
 	[Mod] ->
 	    {Path,St1} = luerl_emul:get_table_keys([<<"package">>,<<"path">>],

--- a/src/luerl_lib_string.erl
+++ b/src/luerl_lib_string.erl
@@ -21,7 +21,8 @@
 -include("luerl.hrl").
 
 %% The basic entry point to set up the function table.
--export([install/1]).
+-export([install/1,byte/3,char/3,dump/3,find/3,format/3,gmatch/3,gsub/3,len/3,lower/3,
+         match/3,rep/3,reverse/3,sub/3,upper/3]).
 
 %% Export some test functions.
 -export([test_gsub/3,test_match_pat/3,test_pat/1,
@@ -45,26 +46,26 @@ metatable(T) ->					%String type metatable
     [{<<"__index">>,T}].
 
 table() ->					%String table
-    [{<<"byte">>,#erl_func{code=fun byte/2}},
-     {<<"char">>,#erl_func{code=fun char/2}},
-     {<<"dump">>,#erl_func{code=fun dump/2}},
-     {<<"find">>,#erl_func{code=fun find/2}},
-     {<<"format">>,#erl_func{code= fun format/2}},
-     {<<"gmatch">>,#erl_func{code=fun gmatch/2}},
-     {<<"gsub">>,#erl_func{code=fun gsub/2}},
-     {<<"len">>,#erl_func{code=fun len/2}},
-     {<<"lower">>,#erl_func{code=fun lower/2}},
-     {<<"match">>,#erl_func{code=fun match/2}},
-     {<<"rep">>,#erl_func{code=fun rep/2}},
-     {<<"reverse">>,#erl_func{code=fun reverse/2}},
-     {<<"sub">>,#erl_func{code=fun sub/2}},
-     {<<"upper">>,#erl_func{code=fun upper/2}}
+    [{<<"byte">>,#erl_mfa{m=?MODULE,f=byte}},
+     {<<"char">>,#erl_mfa{m=?MODULE,f=char}},
+     {<<"dump">>,#erl_mfa{m=?MODULE,f=dump}},
+     {<<"find">>,#erl_mfa{m=?MODULE,f=find}},
+     {<<"format">>,#erl_mfa{m=?MODULE,f=format}},
+     {<<"gmatch">>,#erl_mfa{m=?MODULE,f=gmatch}},
+     {<<"gsub">>,#erl_mfa{m=?MODULE,f=gsub}},
+     {<<"len">>,#erl_mfa{m=?MODULE,f=len}},
+     {<<"lower">>,#erl_mfa{m=?MODULE,f=lower}},
+     {<<"match">>,#erl_mfa{m=?MODULE,f=match}},
+     {<<"rep">>,#erl_mfa{m=?MODULE,f=rep}},
+     {<<"reverse">>,#erl_mfa{m=?MODULE,f=reverse}},
+     {<<"sub">>,#erl_mfa{m=?MODULE,f=sub}},
+     {<<"upper">>,#erl_mfa{m=?MODULE,f=upper}}
     ].
 
 %% byte(String [, I [, J]] ) -> [Code]
 %%  Return numerical codes of string between I and J.
 
-byte(As, St) ->
+byte(_, As, St) ->
     case luerl_lib:conv_list(As, [lua_string,lua_integer,lua_integer]) of
 	[S|Is] ->
 	    Bs = do_byte(S, byte_size(S), Is),
@@ -94,8 +95,8 @@ do_byte_ij(S, _, I, J) ->
 %% char(...) -> String
 %%  Return string of the numerical arguments.
 
-char([nil], St) -> {[<<>>],St};
-char(As, St) ->
+char(_, [nil], St) -> {[<<>>],St};
+char(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	error -> badarg_error(char, As, St);
 	Bs ->
@@ -106,14 +107,14 @@ char(As, St) ->
 %% dump(Function) -> String.
 %%  Return a string with binary representation of Function.
 
--spec dump([_], _) -> no_return().
+-spec dump(_, [_], _) -> no_return().
 
-dump(As, St) -> badarg_error(dump, As, St).
+dump(_, As, St) -> badarg_error(dump, As, St).
 
 %% find(String, Pattern [, Init [, Plain]]) -> [Indice].
 %%  Return first occurrence of Pattern in String.
 
-find(As, St0) ->
+find(_, As, St0) ->
     try
 	do_find(As, St0)
     catch
@@ -161,7 +162,7 @@ do_find(S, L, Pat0, I, false) ->		%Pattern search string
 %%  Format a string. All errors are badarg errors.
 %%  Do all the work in luerl_string_format but generate errors here.
 
-format([F|As], St0) ->
+format(_, [F|As], St0) ->
     try
 	luerl_lib_string_format:format(F, As, St0)
     catch
@@ -170,17 +171,17 @@ format([F|As], St0) ->
 	throw:{error,E} -> lua_error(E, St0);
 	_:_ -> badarg_error(format, [F|As], St0)
     end;
-format(As, St) -> badarg_error(format, As, St).
+format(_, As, St) -> badarg_error(format, As, St).
 
--spec gmatch([_], _) -> no_return().		%To keep dialyzer quiet
+-spec gmatch(_, [_], _) -> no_return().		%To keep dialyzer quiet
 
 %% gmatch(String, Pattern) -> [Function].
 
-gmatch(As, St) -> badarg_error(gmatch, As, St).
+gmatch(_, As, St) -> badarg_error(gmatch, As, St).
 
 %% gsub(String, Pattern, Repl [, N]) -> [String]
 
-gsub(As, St0) ->
+gsub(_, As, St0) ->
     try
 	do_gsub(As, St0)
     catch
@@ -291,14 +292,14 @@ gsub_repl_val(S, Val, Ca) ->
 
 %% len(String) -> Length.
 
-len([A|_], St) when is_binary(A) -> {[byte_size(A)],St};
-len([A|_], St) when is_number(A) ->
+len(_, [A|_], St) when is_binary(A) -> {[byte_size(A)],St};
+len(_, [A|_], St) when is_number(A) ->
     {[length(luerl_lib:number_to_list(A))],St};
-len(As, St) -> badarg_error(len, As, St).
+len(_, As, St) -> badarg_error(len, As, St).
 
 %% lower(String) -> String.
 
-lower(As, St) ->
+lower(_, As, St) ->
     case luerl_lib:conv_list(As, [erl_list]) of
 	[S] -> {[list_to_binary(string:to_lower(S))],St};
 	_ -> badarg_error(lower, As, St)	%nil or []
@@ -306,7 +307,7 @@ lower(As, St) ->
 
 %% match(String, Pattern [, Init]) -> [Match].
 
-match(As, St0) ->
+match(_, As, St0) ->
     try
 	do_match(As, St0)
     catch
@@ -378,8 +379,8 @@ match_caps(Cas, S, I) -> [ match_cap(Ca, S, I) || Ca <- Cas ].
 
 %% rep(String, N [, Separator]) -> [String].
 
-rep([A1,A2], St) -> rep([A1,A2,<<>>], St);
-rep([_,_,_|_]=As, St) ->
+rep(_, [A1,A2], St) -> rep(nil, [A1,A2,<<>>], St);
+rep(_, [_,_,_|_]=As, St) ->
     case luerl_lib:conv_list(As, [lua_string,lua_integer,lua_string]) of
         [S,I,Sep] ->
             Part = [Sep,S],
@@ -399,18 +400,18 @@ rep([_,_,_|_]=As, St) ->
         error ->                                %Error or bad values
             badarg_error(rep, As, St)
     end;
-rep(As, St) -> badarg_error(rep, As, St).
+rep(_, As, St) -> badarg_error(rep, As, St).
 
 %% reverse([String], State) -> {[Res],St}.
 
-reverse([A|_], St) when is_binary(A) ; is_number(A) ->
+reverse(_, [A|_], St) when is_binary(A) ; is_number(A) ->
     S = luerl_lib:arg_to_list(A),
     {[list_to_binary(lists:reverse(S))],St};
-reverse(As, St) -> badarg_error(reverse, As, St).
+reverse(_, As, St) -> badarg_error(reverse, As, St).
 
 %% sub([String, I [, J]], State) -> {[Res],State}.
 
-sub(As, St) ->
+sub(_, As, St) ->
     case luerl_lib:conv_list(As, [lua_string,lua_integer,lua_integer]) of
 	[S,I|Js] ->
 	    Len = byte_size(S),
@@ -440,10 +441,10 @@ do_sub_ij(_, _, I, J) when I > J -> <<>>;
 do_sub_ij(S, _, I, J) ->
     binary:part(S, I-1, J-I+1).			%Zero-based, yuch!
 
-upper([A|_], St) when is_binary(A) ; is_number(A) ->
+upper(_, [A|_], St) when is_binary(A) ; is_number(A) ->
     S = luerl_lib:arg_to_list(A),
     {[list_to_binary(string:to_upper(S))],St};
-upper(As, St) -> badarg_error(upper, As, St).
+upper(_, As, St) -> badarg_error(upper, As, St).
 
 %% This is the pattern grammar used. It may actually be overkill to
 %% first parse the pattern as the pattern is relativey simple and we

--- a/src/luerl_lib_table.erl
+++ b/src/luerl_lib_table.erl
@@ -44,12 +44,12 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"concat">>,#erl_mfa{m=luerl_lib_table,f=concat}},
-     {<<"insert">>,#erl_mfa{m=luerl_lib_table,f=insert}},
-     {<<"pack">>,#erl_mfa{m=luerl_lib_table,f=pack}},
-     {<<"remove">>,#erl_mfa{m=luerl_lib_table,f=remove}},
-     {<<"sort">>,#erl_mfa{m=luerl_lib_table,f=sort}},
-     {<<"unpack">>,#erl_mfa{m=luerl_lib_table,f=unpack}}
+    [{<<"concat">>,#erl_mfa{m=?MODULE,f=concat}},
+     {<<"insert">>,#erl_mfa{m=?MODULE,f=insert}},
+     {<<"pack">>,#erl_mfa{m=?MODULE,f=pack}},
+     {<<"remove">>,#erl_mfa{m=?MODULE,f=remove}},
+     {<<"sort">>,#erl_mfa{m=?MODULE,f=sort}},
+     {<<"unpack">>,#erl_mfa{m=?MODULE,f=unpack}}
     ].
 
 %% concat - concat the elements of a list into a string.

--- a/src/luerl_lib_table.erl
+++ b/src/luerl_lib_table.erl
@@ -44,12 +44,12 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 
 table() ->
-    [{<<"concat">>,#erl_mfa{m=luerl_lib_table,f=concat,a=nil}},
-     {<<"insert">>,#erl_mfa{m=luerl_lib_table,f=insert,a=nil}},
-     {<<"pack">>,#erl_mfa{m=luerl_lib_table,f=pack,a=nil}},
-     {<<"remove">>,#erl_mfa{m=luerl_lib_table,f=remove,a=nil}},
-     {<<"sort">>,#erl_mfa{m=luerl_lib_table,f=sort,a=nil}},
-     {<<"unpack">>,#erl_mfa{m=luerl_lib_table,f=unpack,a=nil}}
+    [{<<"concat">>,#erl_mfa{m=luerl_lib_table,f=concat}},
+     {<<"insert">>,#erl_mfa{m=luerl_lib_table,f=insert}},
+     {<<"pack">>,#erl_mfa{m=luerl_lib_table,f=pack}},
+     {<<"remove">>,#erl_mfa{m=luerl_lib_table,f=remove}},
+     {<<"sort">>,#erl_mfa{m=luerl_lib_table,f=sort}},
+     {<<"unpack">>,#erl_mfa{m=luerl_lib_table,f=unpack}}
     ].
 
 %% concat - concat the elements of a list into a string.

--- a/src/luerl_lib_utf8.erl
+++ b/src/luerl_lib_utf8.erl
@@ -28,12 +28,12 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"char">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_char}},
+    [{<<"char">>,#erl_mfa{m=?MODULE,f=utf8_char}},
      {<<"charpattern">>,<<"[\0-\x7F\xC2-\xF4][\x80-\xBF]*">>},
-     {<<"codes">>,#erl_mfa{m=luerl_lib_utf8,f=codes}},
-     {<<"codepoint">>,#erl_mfa{m=luerl_lib_utf8,f=codepoint}},
-     {<<"len">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_len}},
-     {<<"offset">>,#erl_mfa{m=luerl_lib_utf8,f=offset}}
+     {<<"codes">>,#erl_mfa{m=?MODULE,f=codes}},
+     {<<"codepoint">>,#erl_mfa{m=?MODULE,f=codepoint}},
+     {<<"len">>,#erl_mfa{m=?MODULE,f=utf8_len}},
+     {<<"offset">>,#erl_mfa{m=?MODULE,f=offset}}
     ].
 
 %% char(...) -> String.

--- a/src/luerl_lib_utf8.erl
+++ b/src/luerl_lib_utf8.erl
@@ -28,12 +28,12 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"char">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_char,a=nil}},
+    [{<<"char">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_char}},
      {<<"charpattern">>,<<"[\0-\x7F\xC2-\xF4][\x80-\xBF]*">>},
-     {<<"codes">>,#erl_mfa{m=luerl_lib_utf8,f=codes,a=nil}},
-     {<<"codepoint">>,#erl_mfa{m=luerl_lib_utf8,f=codepoint,a=nil}},
-     {<<"len">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_len,a=nil}},
-     {<<"offset">>,#erl_mfa{m=luerl_lib_utf8,f=offset,a=nil}}
+     {<<"codes">>,#erl_mfa{m=luerl_lib_utf8,f=codes}},
+     {<<"codepoint">>,#erl_mfa{m=luerl_lib_utf8,f=codepoint}},
+     {<<"len">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_len}},
+     {<<"offset">>,#erl_mfa{m=luerl_lib_utf8,f=offset}}
     ].
 
 %% char(...) -> String.

--- a/src/luerl_lib_utf8.erl
+++ b/src/luerl_lib_utf8.erl
@@ -20,7 +20,7 @@
 
 -include("luerl.hrl").
 
--export([install/1]).
+-export([install/1,utf8_char/3,codes/3,codepoint/3,utf8_len/3,offset/3]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]). %Shorten these
 
@@ -28,12 +28,12 @@ install(St) ->
     luerl_heap:alloc_table(table(), St).
 
 table() ->
-    [{<<"char">>,#erl_func{code=fun utf8_char/2}},
+    [{<<"char">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_char,a=nil}},
      {<<"charpattern">>,<<"[\0-\x7F\xC2-\xF4][\x80-\xBF]*">>},
-     {<<"codes">>,#erl_func{code=fun codes/2}},
-     {<<"codepoint">>,#erl_func{code=fun codepoint/2}},
-     {<<"len">>,#erl_func{code=fun utf8_len/2}},
-     {<<"offset">>,#erl_func{code=fun offset/2}}
+     {<<"codes">>,#erl_mfa{m=luerl_lib_utf8,f=codes,a=nil}},
+     {<<"codepoint">>,#erl_mfa{m=luerl_lib_utf8,f=codepoint,a=nil}},
+     {<<"len">>,#erl_mfa{m=luerl_lib_utf8,f=utf8_len,a=nil}},
+     {<<"offset">>,#erl_mfa{m=luerl_lib_utf8,f=offset,a=nil}}
     ].
 
 %% char(...) -> String.
@@ -41,7 +41,7 @@ table() ->
 %%  corresponding UTF-8 byte sequence and returns a string with the
 %%  concatenation of all these sequences.
 
-utf8_char(As, St) ->
+utf8_char(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	Is when is_list(Is) ->
 	    Ss = << <<I/utf8>> || I <- Is >>,
@@ -55,7 +55,7 @@ utf8_char(As, St) ->
 %%  and for j is -1. If it finds any invalid byte sequence, returns a
 %%  false value plus the position of the first invalid byte.
 
-utf8_len(As, St) ->
+utf8_len(_, As, St) ->
     {Str,I,J} = string_args(As, len, St),
     StrLen = byte_size(Str),
     Ret = if I > J -> [0];			%Do the same as Lua
@@ -70,7 +70,7 @@ utf8_len(As, St) ->
 
 bin_len(Bin, Last, N) when byte_size(Bin) =< Last -> {ok,N};
 bin_len(Bin0, Last, N) ->
-    try 
+    try
 	<<_/utf8,Bin1/binary>> = Bin0,
 	bin_len(Bin1, Last, N+1)
     catch
@@ -83,7 +83,7 @@ bin_len(Bin0, Last, N) ->
 %%  for i is 1 and for j is i. It raises an error if it meets any
 %%  invalid byte sequence.
 
-codepoint(As, St) ->
+codepoint(_, As, St) ->
     {Str,I,J} = string_args(As, codepoint, St),
     StrLen = byte_size(Str),
     Ret = if I > J -> [];			%Do the same as Lua
@@ -99,7 +99,7 @@ codepoint(As, St) ->
 bin_codepoint(Bin, Last, Cps) when byte_size(Bin) =< Last ->
     {ok,lists:reverse(Cps)};
 bin_codepoint(Bin0, Last, Cps) ->
-    try 
+    try
 	<<C/utf8,Bin1/binary>> = Bin0,
 	bin_codepoint(Bin1, Last, [C|Cps])
     catch
@@ -108,7 +108,7 @@ bin_codepoint(Bin0, Last, Cps) ->
 
 %% codes(String) -> [Fun,String,P].
 
-codes(As, St) ->
+codes(_, As, St) ->
     case luerl_lib:conv_list(As, [lua_string]) of
 	error -> badarg_error(codes, As, St);
 	[Str|_] -> {[#erl_func{code=fun codes_next/2},Str,0],St}
@@ -122,9 +122,9 @@ codes_next([Str,P|_], St) when is_binary(Str) ->
     {[P1,C],St}.
 
 %% offset(String, N, ...) -> Integer.
--spec offset([_], any()) -> no_return().
+-spec offset(_, [_], any()) -> no_return().
 
-offset(As, St) ->
+offset(_, As, St) ->
     _ = string_args(As, offset, St),
     %% We don't do anything yet.
     lua_error({'NYI',offset}, St).

--- a/src/luerl_new.erl
+++ b/src/luerl_new.erl
@@ -42,6 +42,9 @@
 %% Encoding and decoding.
 -export([encode/2,encode_list/2,decode/2,decode_list/2]).
 
+%% Helping with storing VM state
+-export([externalize/1,internalize/1]).
+
 %% init() -> State.
 
 init() ->
@@ -442,3 +445,14 @@ decode_table(#tref{i=N}=T, St, In0) ->
 decode_userdata(U, St) ->
     {#userdata{d=Data},_} = luerl_heap:get_userdata(U, St),
     {userdata,Data}.
+
+
+%% Externalize and Internalize ensure that the VM state passed in
+%% can be stored externally or can be recreated from external storage.
+%% Currently very simple: only random state needs special treatment.
+
+externalize(S) ->
+    luerl_lib_math:externalize(S).
+
+internalize(S) ->
+    luerl_lib_math:internalize(S).

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -33,7 +33,7 @@ external_fun_test() ->
     ?assertEqual(true, BoolVal),
     ?assertEqual(true, BoolVal2),
     ?assertEqual(true, BoolVal3).
-    
+
 external_nostate_fun_test() ->
     State = luerl:init(),
     F = fun([A]) ->
@@ -54,8 +54,8 @@ external_nostate_fun_test() ->
 return_lib_function_test() ->
     State = luerl:init(),
     {_, State1} = luerl:do(<<"function test()\n  return string.find  end\n">>, State),
-    {[Fun], _State2} = luerl:call_function([test], [1], State1),
-    {Res, _State3} = Fun([<<"barfooblafasel">>, <<"foo">>], State1),
+    {[{M,F,A}], _State2} = luerl:call_function([test], [1], State1),
+    {Res, _State3} = apply(M, F, [A, [<<"barfooblafasel">>, <<"foo">>], State1]),
     ?assertEqual([4, 6], Res).
 
 define_fun_in_lua_test() ->


### PR DESCRIPTION
[Copy/continuation of #155]

This leaves the current function reference support in place, but adds support for MFA triplets. Without these references, Lua VM states become externalizable. 

Even though the "A" is not used at the moment, MFA is a standard way to reference functions in Erlang and the added argument does not add a lot of overhead but should allow for "neat stuff". 

All library functions have been converted, which means that the result of `luerl:init()` is now externalizable. 