### PR TITLE
Support compilation with Erlang/OTP 27.0-rc1

### DIFF
--- a/src/luerl_comp.hrl
+++ b/src/luerl_comp.hrl
@@ -74,7 +74,7 @@
 		    gens,			%Generators
 		    body=[]}).			%Loop body
 
--record(if_stmt, {l,tests=[],else}).
+-record(if_stmt, {l,tests=[],else_block}).
 
 -record(local_assign_stmt, {l,vars,exps}).
 

--- a/src/luerl_comp_cg.erl
+++ b/src/luerl_comp_cg.erl
@@ -219,7 +219,7 @@ repeat_stmt(#repeat_stmt{body=B}, St0) ->
 %%  test-block. This means more nested calls but simpler emulator
 %%  code.
 
-if_stmt(#if_stmt{tests=Ts,else=E}, St) ->
+if_stmt(#if_stmt{tests=Ts,else_block=E}, St) ->
     if_tests(Ts, E, St).
 
 if_tests([{E,B}], #block{body=[]}, St0) ->

--- a/src/luerl_comp_env.erl
+++ b/src/luerl_comp_env.erl
@@ -252,10 +252,10 @@ repeat_stmt(#repeat_stmt{body=B0}=R, St0) ->
 
 %% if_stmt(If, State) -> {If,State}.
 
-if_stmt(#if_stmt{tests=Ts0,else=E0}=I, St0) ->
+if_stmt(#if_stmt{tests=Ts0,else_block=E0}=I, St0) ->
     {Ts1,St1} = if_tests(Ts0, St0),
     {E1,St2} = do_block(E0, St1),
-    {I#if_stmt{tests=Ts1,else=E1},St2}.
+    {I#if_stmt{tests=Ts1,else_block=E1},St2}.
 
 if_tests([{E0,B0}|Ts0], St0) ->
     {E1,St1} = exp(E0, St0),

--- a/src/luerl_comp_lint.erl
+++ b/src/luerl_comp_lint.erl
@@ -132,7 +132,7 @@ while_stmt(#while_stmt{exp=Exp,body=Ss}, St0) ->
 repeat_stmt(#repeat_stmt{body=Ss}, St) ->
     block(Ss, St).
 
-if_stmt(#if_stmt{tests=Ts,else=Else}, St0) ->
+if_stmt(#if_stmt{tests=Ts,else_block=Else}, St0) ->
     Fun = fun ({E,B}, S0) ->
                   S1 = exp(E, S0),
                   block(B, S1)

--- a/src/luerl_comp_locf.erl
+++ b/src/luerl_comp_locf.erl
@@ -140,11 +140,11 @@ repeat_stmt(#repeat_stmt{body=B0}=R, St0) ->
 %%  The block info includes anything from the test expressions even
 %%  though we keep them separate.
 
-if_stmt(#if_stmt{tests=Ts0,else=E0}=If, St0) ->
+if_stmt(#if_stmt{tests=Ts0,else_block=E0}=If, St0) ->
     {Ts1,Tlocf,St1} = if_tests(Ts0, St0),
     {E1,Elocf,St2} = do_block(E0, St1),
     Locf = Tlocf or Elocf,
-    {If#if_stmt{tests=Ts1,else=E1},Locf,St2}.
+    {If#if_stmt{tests=Ts1,else_block=E1},Locf,St2}.
 
 if_tests([{E0,B0}|Ts0], St0) ->
     {E1,Elocf,St1} = exp(E0, St0),

--- a/src/luerl_comp_normalise.erl
+++ b/src/luerl_comp_normalise.erl
@@ -163,7 +163,7 @@ if_stmt(Line, Tests, Else, St0) ->
     {Cts,St1} = if_tests(Line, Tests, St0),
     {Ce,St2} = block(Line, Else, St1),
     Anno = line_file_anno(Line, St2),
-    {#if_stmt{l=Anno,tests=Cts,else=Ce},St2}.
+    {#if_stmt{l=Anno,tests=Cts,else_block=Ce},St2}.
 
 if_tests(L, Ts, St) ->
     Test = fun ({T,B}, S0) ->

--- a/src/luerl_comp_vars.erl
+++ b/src/luerl_comp_vars.erl
@@ -186,12 +186,12 @@ repeat_stmt(#repeat_stmt{body=B0}=R, _, St0) ->
 %%  The block info includes anything from the test expressions even
 %%  though we keep them separate.
 
-if_stmt(#if_stmt{tests=Ts0,else=E0}=If, Loc, St0) ->
+if_stmt(#if_stmt{tests=Ts0,else_block=E0}=If, Loc, St0) ->
     {Ts1,Tused,Tfused,St1} = if_tests(Ts0, Loc, St0),
     {E1,Eused,Efused,St2} = do_block(E0, St1),
     Used = union(Tused, Eused),
     Fused = union(Tfused, Efused),
-    {If#if_stmt{tests=Ts1,else=E1},[],Used,Fused,St2}.
+    {If#if_stmt{tests=Ts1,else_block=E1},[],Used,Fused,St2}.
 
 if_tests([{E0,B0}|Ts0], Loc, St0) ->
     {E1,Eused,Efused,St1} = exp(E0, Loc, St0),


### PR DESCRIPTION
Compiling Luerl with Erlang/OTP 27.0-rc1 fails with error message `syntax error before: 'else'`:

<details>

```
$ make
erlc -W1 -o ./ebin -DERLANG_VERSION=\"27.0-rc1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -DNEW_BOOL_GUARD=true -DHAS_FLOOR=true -DHAS_CEIL=true -DNEW_STACKTRACE=true -DEEP48=true  -W1 src/Elixir.Luerl.erl
erlc -W1 -o ./ebin -DERLANG_VERSION=\"27.0-rc1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -DNEW_BOOL_GUARD=true -DHAS_FLOOR=true -DHAS_CEIL=true -DNEW_STACKTRACE=true -DEEP48=true  -W1 src/Elixir.Luerl.New.erl
erlc -W1 -o ./ebin -DERLANG_VERSION=\"27.0-rc1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -DNEW_BOOL_GUARD=true -DHAS_FLOOR=true -DHAS_CEIL=true -DNEW_STACKTRACE=true -DEEP48=true  -W1 src/luerl_anno.erl
erlc -W1 -o ./ebin -DERLANG_VERSION=\"27.0-rc1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -DNEW_BOOL_GUARD=true -DHAS_FLOOR=true -DHAS_CEIL=true -DNEW_STACKTRACE=true -DEEP48=true  -W1 src/luerl_app.erl
erlc -W1 -o ./ebin -DERLANG_VERSION=\"27.0-rc1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -DNEW_BOOL_GUARD=true -DHAS_FLOOR=true -DHAS_CEIL=true -DNEW_STACKTRACE=true -DEEP48=true  -W1 src/luerl_comp_cg.erl
src/luerl_comp.hrl:77:30: syntax error before: 'else'
%   77| -record(if_stmt, {l,tests=[],else}).
%     |                              ^

src/luerl_comp_cg.erl:222:27: syntax error before: 'else'
%  222| if_stmt(#if_stmt{tests=Ts,else=E}, St) ->
%     |                           ^

src/luerl_comp_cg.erl:89:6: record if_stmt undefined
%   89| stmt(#if_stmt{}=I, _, St) -> if_stmt(I, St);
%     |      ^

src/luerl_comp_cg.erl:89:30: function if_stmt/2 undefined
%   89| stmt(#if_stmt{}=I, _, St) -> if_stmt(I, St);
%     |                              ^

src/luerl_comp_cg.erl:225:1: Warning: function if_tests/3 is unused
%  225| if_tests([{E,B}], #block{body=[]}, St0) ->
%     | ^

make: *** [Makefile:53: ebin/luerl_comp_cg.beam] Error 1
```
</details>

 This is because `else` is now a reserved keyword, similarly to `maybe`. The solution is quite simple: quote `else` to ensure the compiler treats it as an atom and not a keyword.

https://erlang.org/documentation/doc-15.0-rc1/doc/upcoming_incompatibilities.html#feature-maybe_expr-will-be-enabled-by-default

