### PR TITLE
enable os.time to convert date table to a number

### DIFF
--- a/src/luerl_lib_os.erl
+++ b/src/luerl_lib_os.erl
@@ -251,8 +251,8 @@ compute_time(Map=#{<<"year">> := Y, <<"month">> := Mth, <<"day">> := D}, _, St) 
     H = maps:get(<<"hour">>, Map, 12),
     Min = maps:get(<<"min">>, Map, 0),
     S = maps:get(<<"sec">>, Map, 0),
-    %% 62167219200 = calendar:datetime_to_gregorian_seconds({1970, 1, 1}, {0, 0, 0})
-    Result = calendar:datetime_to_gregorian_seconds({{Y, Mth, D}, {H, Min, S}}) - 62167219200,
+    LocalEpoch = calendar:universal_time_to_local_time({{1970,1,1},{0,0,0}}),
+    Result = calendar:datetime_to_gregorian_seconds({{Y, Mth, D}, {H, Min, S}}) - calendar:datetime_to_gregorian_seconds(LocalEpoch),
     {[Result],St};
 compute_time(_, As, St) ->
     badarg_error(time, As, St).

--- a/src/luerl_lib_os.erl
+++ b/src/luerl_lib_os.erl
@@ -254,8 +254,13 @@ compute_time(Map=#{<<"year">> := Y, <<"month">> := Mth, <<"day">> := D}, _, St) 
     LocalEpoch = calendar:universal_time_to_local_time({{1970,1,1},{0,0,0}}),
     Result = calendar:datetime_to_gregorian_seconds({{Y, Mth, D}, {H, Min, S}}) - calendar:datetime_to_gregorian_seconds(LocalEpoch),
     {[Result],St};
-compute_time(_, As, St) ->
-    badarg_error(time, As, St).
+compute_time(Map, _As, St) ->
+    MissingArg = lists:foldl(fun(K,Acc=undefined) -> case maps:is_key(K, Map) of
+                                                         false -> K;
+                                                         true -> Acc
+                                                     end;
+                                (_,Acc) -> Acc end, undefined, [<<"day">>, <<"month">>, <<"year">>]),
+    badarg_error(time, MissingArg, St).
 
 current_timestamp() ->
     {Mega,Sec,Micro} = os:timestamp(),


### PR DESCRIPTION
Examples enabled:
```
os.time{year=2024, month=4, day=30}
os.time{year=2024, month=4, day=30, hour=10, min=30}
```

Similar to Lua, year, month and day are mandatory.  Hour, min and sec default to noon.