### PR TITLE
io:format -> logger

### DIFF
--- a/examples/hello/hello_sandbox.erl
+++ b/examples/hello/hello_sandbox.erl
@@ -7,37 +7,55 @@
 -export([run/0]).
 
 run() ->
-    %% sandboxing globals
-    St0 = luerl_sandbox:init(),
-    {error, {lua_error, Reason, _}} = luerl_sandbox:run("return os.getenv(\"HOME\")"),
+    %% Default sandboxed state.
+    SbSt = luerl_sandbox:init(),
+
+    %% Sandboxing globals
+    {error, {lua_error, Reason, _}} =
+        luerl_sandbox:run("return os.getenv(\"HOME\")", SbSt),
     io:format("os.getenv with sandbox: ~p~n",[Reason]),
 
-    %% customizing sandbox
+    %% Customizing sandbox
+    %%  first with default Luerl state.
     {[<<"number">>], _} = luerl_sandbox:run("return type(1)", luerl:init()),
-    {error,  {lua_error, _, _}} = luerl_sandbox:run("return type(1)", luerl_sandbox:init([['_G', type]])),
 
-    %% using sandboxed state outside of runner
+    %%  then with sandboxed type function
+    {error,  {lua_error, _, _}} =
+        luerl_sandbox:run("return type(1)", luerl_sandbox:init([['_G', type]])),
+
+    %% Using sandboxed state outside of runner
     try
-        luerl:do("return os.getenv(\"HOME\")", St0)
+        luerl:do("return os.getenv(\"HOME\")", SbSt)
     catch
         _:_ ->
             io:format("catch error with os.getenv(\"HOME\") with sandbox~n", [])
     end,
 
-    %% script runner with reduction counting and process flags
+    %% Setting values.
     MaxReductions = 100,
-    ProcessFlags = [{priority, low}],
+    SpawnOpts = [{priority, low}],
     Timeout = 1000,
-    {error, {reductions, R0}} = luerl_sandbox:run("a={}; for i=1,1000000 do a[i] = 5 end", St0, MaxReductions),
+
+    %% Script runner with reduction counting.
+    Flags0 = #{max_reductions => MaxReductions},
+    {error, {reductions, R0}} =
+        luerl_sandbox:run("a={}; for i=1,1000000 do a[i] = 5 end",
+                          Flags0, SbSt),
     io:format("killed process with reductions ~p > 100~n",[R0]),
-    {error, {reductions, R1}} = luerl_sandbox:run("x = 'a'; while true do x = x .. x end", luerl:init(), MaxReductions, ProcessFlags, Timeout),
+
+    %% Sandboxed run with default Luerl state.
+    Flags1 = #{max_reductions => MaxReductions,
+               spawn_opts => SpawnOpts,
+               max_time => Timeout},
+    {error, {reductions, R1}} =
+        luerl_sandbox:run("x = 'a'; while true do x = x .. x end",
+                          Flags1, luerl:init()),
     io:format("killed process with reductions ~p > 100~n",[R1]),
 
-    %% unlimited reductions
-    UnlimitedReductions = 0,
-    {[], _} = luerl_sandbox:run("a={}; for i=1,10 do a[i] = 5 end", St0, UnlimitedReductions),
+    %% Unlimited reductions
+    Flags3 = #{max_reductions => none},
+    {[], _} = luerl_sandbox:run("a={}; for i=1,10 do a[i] = 5 end",
+                                Flags3, SbSt),
     io:format("Finished running with unlimited reductions ~n",[]),
 
     done.
-
-


### PR DESCRIPTION
This changes the printing to use the standard logger and removes one forgotten debug print statement.