### PR TITLE
feature: io:format -> logger

### DIFF
--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -313,17 +313,17 @@ debug_print(Opts, Format, Args) ->
 list_warnings(F, Ws) ->
     foreach(fun ({Line,Mod,Warn}) ->
                     Cs = Mod:format_error(Warn),
-                    io:format("~s:~w: Warning: ~s\n", [F,Line,Cs]);
+                    logger:warning("~s:~w: Warning: ~s\n", [F,Line,Cs]);
                 ({Mod,Warn}) ->
                     Cs = Mod:format_error(Warn),
-                    io:format("~s: Warning: ~s\n", [F,Cs])
+                    logger:warning("~s: Warning: ~s\n", [F,Cs])
             end, Ws).
 
 list_errors(F, Es) ->
     foreach(fun ({Line,Mod,Error}) ->
                     Cs = Mod:format_error(Error),
-                    io:format("~s:~w: ~s\n", [F,Line,Cs]);
+                    logger:error("~s:~w: ~s\n", [F,Line,Cs]);
                 ({Mod,Error}) ->
                     Cs = Mod:format_error(Error),
-                    io:format("~s: ~s\n", [F,Cs])
+                    logger:error("~s: ~s\n", [F,Cs])
             end, Es).

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -88,8 +88,8 @@ collectgarbage(_, _, St) ->			%Ignore everything else
 eprint(_, Args, St) ->
     lists:foreach(fun (#tref{}=Tref) ->
 			  Tab = luerl_heap:get_table(Tref, St),
-			  io:format("~w ", [Tab]);
-		      (A) -> io:format("~w ", [A])
+			  logger:error("~w ", [Tab]);
+		      (A) -> logger:error("~w ", [A])
 		  end, Args),
     io:nl(),
     {[],St}.
@@ -204,7 +204,7 @@ next_key(K, Dict, St) ->
 print(_, Args, St0) ->
     St1 = lists:foldl(fun (A, S0) ->
 			      {[Str],S1} = tostring([A], S0),
-			      io:format("~ts ", [Str]),
+			      logger:info("~ts ", [Str]),
 			      S1
 		      end, St0, Args),
     io:nl(),

--- a/src/luerl_lib_io.erl
+++ b/src/luerl_lib_io.erl
@@ -42,6 +42,6 @@ write(_, As, St) ->
     case luerl_lib:args_to_strings(As) of
 	error -> badarg_error(write, As, St);
 	Ss ->
-	    lists:foreach(fun (S) -> io:format("~s", [S]) end, Ss),
+	    lists:foreach(fun (S) -> logger:info("~s", [S]) end, Ss),
 	    {[#userdata{d=standard_io}],St}
     end.


### PR DESCRIPTION
This switches the main printing mechanism to the standard logger. This is useful when integrating Luerl into existing systems and reporting things like compiler errors, etc.