### PR TITLE
fix: unicode:characers_to_binary -> unicode:characters_to_binary

### DIFF
--- a/src/luerl_lib_package.erl
+++ b/src/luerl_lib_package.erl
@@ -215,5 +215,5 @@ lua_searcher_ret({ok,Chunk}, File, St0) ->
     {Func,St1} = luerl_emul:load_chunk(Chunk, St0),
     {[Func,File],St1};
 lua_searcher_ret({error,[{_,Mod,E}|_],_}, _, St) ->
-    Msg = unicode:characers_to_binary(Mod:format_error(E)),
+    Msg = unicode:characters_to_binary(Mod:format_error(E)),
     {[Msg],St}.


### PR DESCRIPTION
Fixes a typo in this function. Found through `dialyzer`