### PR TITLE
Allow tref to pass through encode/2

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -375,6 +375,12 @@ encode({M,F,A}, St) when is_atom(M) and is_atom(F) ->
     {#erl_mfa{m=M,f=F,a=A}, St};
 encode({userdata,Data}, St) ->
     luerl_heap:alloc_userdata(Data, St);
+% Table refs should not be re-encoded
+encode(#tref{}=T, St) ->
+    case luerl_heap:chk_table(T, St) of
+        ok -> {T, St};
+        error -> error(badarg)
+    end;
 encode(_, _) -> error(badarg).			%Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].

--- a/src/luerl_new.erl
+++ b/src/luerl_new.erl
@@ -397,7 +397,10 @@ encode({userdata,Data}, St) ->
     luerl_heap:alloc_userdata(Data, St);
 % Table refs should not be re-encoded
 encode(#tref{}=T, St) ->
-    {T, St};
+    case luerl_heap:chk_table(T, St) of
+        ok -> {T, St};
+        error -> error(badarg)
+    end;
 encode(_, _) -> error(badarg).                  %Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].

--- a/src/luerl_new.erl
+++ b/src/luerl_new.erl
@@ -395,7 +395,11 @@ encode({M,F,A}, St) when is_atom(M) and is_atom(F) ->
     {#erl_mfa{m=M,f=F,a=A}, St};
 encode({userdata,Data}, St) ->
     luerl_heap:alloc_userdata(Data, St);
+% Table refs should not be re-encoded
+encode(#tref{}=T, St) ->
+    {T, St};
 encode(_, _) -> error(badarg).                  %Can't encode anything else
+
 
 %% decode_list([LuerlTerm], State) -> [Term].
 %% decode(LuerlTerm, State) -> Term.

--- a/src/luerl_new.erl
+++ b/src/luerl_new.erl
@@ -400,7 +400,6 @@ encode(#tref{}=T, St) ->
     {T, St};
 encode(_, _) -> error(badarg).                  %Can't encode anything else
 
-
 %% decode_list([LuerlTerm], State) -> [Term].
 %% decode(LuerlTerm, State) -> Term.
 %%  In decode we track of which tables we have seen to detect

--- a/test/luerl_new_tests.erl
+++ b/test/luerl_new_tests.erl
@@ -1,0 +1,26 @@
+- module(luerl_new_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+encode_test() ->
+    State = luerl_new:init(),
+    ?assertMatch({nil, _State}, luerl_new:encode(nil, State)),
+    ?assertMatch({false, _State}, luerl_new:encode(false, State)),
+    ?assertMatch({true, _State}, luerl_new:encode(true, State)),
+    ?assertMatch({<<"binary">>, _State}, luerl_new:encode(<<"binary">>, State)),
+    ?assertMatch({<<"atom">>, _State}, luerl_new:encode(atom, State)),
+    ?assertMatch({5, _State}, luerl_new:encode(5, State)),
+    ?assertMatch({{tref, _}, _State}, luerl_new:encode(#{a => 1, b => 2}, State)).
+
+encode_map_test() ->
+    ?assertMatch({{tref, _}, _State}, luerl_new:encode(#{a => 1}, luerl_new:init())).
+
+encode_table_test() ->
+    {Table, State} = luerl_new:encode(#{a => 1}, luerl_new:init()),
+    {ok, [], State1} = luerl_new:set_table_keys([<<"foo">>], Table, State),
+    ?assertMatch({ok, Table, _State2}, luerl_new:get_table_keys([<<"foo">>], State1)),
+    ?assertMatch({tref, _}, Table),
+    ?assertMatch({Table, _State}, luerl_new:encode(Table, State1)).
+
+invalid_table_test() ->
+    ?assertException(error, badarg, luerl_new:encode({tref, 42}, luerl_new:init())).

--- a/test/luerl_tests.erl
+++ b/test/luerl_tests.erl
@@ -1,0 +1,24 @@
+- module(luerl_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+encode_test() ->
+    State = luerl:init(),
+    ?assertMatch({nil, _State}, luerl:encode(nil, State)),
+    ?assertMatch({false, _State}, luerl:encode(false, State)),
+    ?assertMatch({true, _State}, luerl:encode(true, State)),
+    ?assertMatch({<<"binary">>, _State}, luerl:encode(<<"binary">>, State)),
+    ?assertMatch({<<"atom">>, _State}, luerl:encode(atom, State)),
+    ?assertMatch({5, _State}, luerl:encode(5, State)),
+    ?assertMatch({{tref, _}, _State}, luerl:encode(#{a => 1, b => 2}, State)).
+
+encode_map_test() ->
+    ?assertMatch({{tref, _}, _State}, luerl:encode(#{a => 1}, luerl:init())).
+
+encode_table_test() ->
+    {Table, State} = luerl:encode(#{a => 1}, luerl:init()),
+    ?assertMatch({tref, _}, Table),
+    ?assertMatch({Table, _State}, luerl:encode(Table, State)).
+
+invalid_table_test() ->
+    ?assertException(error, badarg, luerl:encode({tref, 42}, luerl:init())).


### PR DESCRIPTION
There are times when a `tref` may be passed to Erlang/Elixir, and then we want to return it as-is (or modified) to the emulator. Currently, this will fail when Luerl tries to re-encode the value.

Instead, we should just pass through these values as is