### PR TITLE
Prevent build machine paths being used in published artifacts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,10 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
+%% Prevent build directories being used in output files
+{xrl_opts, [{deterministic, true}]}.
+{yrl_opts, [{deterministic, true}]}.
+
 {shell, [
   % {config, "config/sys.config"},
     {apps, [luerl]}

--- a/rebar.config
+++ b/rebar.config
@@ -3,10 +3,6 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-%% Prevent build directories being used in output files
-{xrl_opts, [{deterministic, true}]}.
-{yrl_opts, [{deterministic, true}]}.
-
 {shell, [
   % {config, "config/sys.config"},
     {apps, [luerl]}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,6 +1,6 @@
 %% -*- mode: erlang; indent-tabs-mode: nil -*-
 
-Conf0 = CONFIG,                                 %The original config
+Conf0 = CONFIG,                                 % The original config
 
 %% Do a deep set stepping down a list of keys replacing/adding last
 %% with value. Named funs would be nicer but not always available.
@@ -78,12 +78,35 @@ Copts = Copts0 ++ AppendCopts(Version,
 %% Ensure they are in erl_opts.
 
 Conf1 = case lists:keyfind(erl_opts, 1, Conf0) of
-            {erl_opts,Opts} ->                  %Existing erl_opts
+            {erl_opts,Opts} ->                  % Existing erl_opts
                 NewOpts = {erl_opts,Opts ++ Copts},
                 lists:keyreplace(erl_opts, 1, Conf0, NewOpts);
-            false ->                            %No erl_opts
+            false ->                             % No erl_opts
                 Conf0 ++ [{erl_opts,Copts}]
         end,
+
+%% Prevent build directories being used in output files
+
+XrlYrlOpts = if Version > "24" ->
+                 [
+                    {xrl_opts, [{deterministic, true}]},
+                    {yrl_opts, [{deterministic, true}]}
+                 ];
+             true ->
+                 []
+         end,
+
+%% Append the new options to the configuration.
+
+Conf2 = lists:foldl(fun({Key, Val}, Acc) ->
+                        case lists:keyfind(Key, 1, Acc) of
+                            {Key, OldVal} ->
+                                NewVal = {Key, OldVal ++ Val},
+                                lists:keyreplace(Key, 1, Acc, NewVal);
+                            false ->
+                                Acc ++ [{Key, Val}]
+                        end
+                    end, Conf1, XrlYrlOpts),
 
 %% TestConfig = [{cover_enabled, true}, {cover_opts, [verbose]}],
 
@@ -91,6 +114,6 @@ Conf1 = case lists:keyfind(erl_opts, 1, Conf0) of
 %%     {test, [eunit, {ct, "--cover"}, cover]}
 %% ]}],
 
-%% Conf1 ++ TestConfig ++ Aliases.
+%% Conf2 ++ TestConfig ++ Aliases.
 
-Conf1.
+Conf2.


### PR DESCRIPTION
Currently, wherever `luerl` is built before publishing will include the user's local filesystem paths.  You can see @rvirding path's in hexpm https://preview.hex.pm/preview/luerl/1.2.2/show/src/luerl_scan.erl

```erlang
%% User code. This is placed here to allow extra attributes.
-file("/Users/rv/luerl/luerl/src/luerl_scan.xrl", 139).
```

This fixes the compiler to always use just the basename to prevent this leakage.

```erlang
%% User code. This is placed here to allow extra attributes.
-file("luerl_scan.xrl", 139).
```