### PR TITLE
Include value in badarg encoding

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -381,7 +381,7 @@ encode(#tref{}=T, St) ->
         ok -> {T, St};
         error -> error(badarg)
     end;
-encode(_, _) -> error(badarg).			%Can't encode anything else
+encode(Val, _) -> error({badarg, Val}).			%Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].
 %% decode(LuerlTerm, State) -> Term.

--- a/src/luerl_new.erl
+++ b/src/luerl_new.erl
@@ -401,7 +401,7 @@ encode(#tref{}=T, St) ->
         ok -> {T, St};
         error -> error(badarg)
     end;
-encode(_, _) -> error(badarg).                  %Can't encode anything else
+encode(Val, _) -> error({badarg, Val}).                  %Can't encode anything else
 
 %% decode_list([LuerlTerm], State) -> [Term].
 %% decode(LuerlTerm, State) -> Term.

--- a/test/luerl_new_tests.erl
+++ b/test/luerl_new_tests.erl
@@ -24,3 +24,6 @@ encode_table_test() ->
 
 invalid_table_test() ->
     ?assertException(error, badarg, luerl_new:encode({tref, 42}, luerl_new:init())).
+
+invalid_value_test() ->
+    ?assertException(error, {badarg, {invalid, value}}, luerl_new:encode({invalid, value}, luerl_new:init())).

--- a/test/luerl_tests.erl
+++ b/test/luerl_tests.erl
@@ -22,3 +22,6 @@ encode_table_test() ->
 
 invalid_table_test() ->
     ?assertException(error, badarg, luerl:encode({tref, 42}, luerl:init())).
+
+invalid_value_test() ->
+    ?assertException(error, {badarg, {invalid, value}}, luerl:encode({invalid, value}, luerl_new:init())).


### PR DESCRIPTION
When trying to encode a bad value, include it in the error for nicer error messages.

Pulled from #27 and added tests