### PR TITLE
fix: allow loading files with only comments

### DIFF
--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -235,10 +235,12 @@ do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
 	    Ret =
           case io:request(F, {get_until,unicode,'',luerl_scan,tokens,[1]}) of
               {ok,Ts,_} ->
-              debug_print(Opts, "scan: ~p\n", [Ts]),
-              {ok,St#luacomp{code=Ts}};
-              {eof,_} -> {ok,St#luacomp{code=[]}};
-              {error,E,_} -> {error,St#luacomp{errors=[E]}}
+                  debug_print(Opts, "scan: ~p\n", [Ts]),
+                  {ok,St#luacomp{code=Ts}};
+              {eof,_} ->
+                  {ok,St#luacomp{code=[]}};
+              {error,E,_} ->
+                  {error,St#luacomp{errors=[E]}}
           end,
         file:close(F),
 	    Ret;

--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -236,6 +236,7 @@ do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
 		      {ok,Ts,_} ->
 			  debug_print(Opts, "scan: ~p\n", [Ts]),
 			  {ok,St#luacomp{code=Ts}};
+              {eof,_} -> {ok,St#luacomp{code=[]}};
 		      {error,E,_} -> {error,St#luacomp{errors=[E]}}
 		  end,
 	    file:close(F),

--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -232,14 +232,15 @@ do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
 		_ -> file:position(F, bof)	%Get it all
 	    end,
 	    %% Now read the file.
-	    Ret = case io:request(F, {get_until,unicode,'',luerl_scan,tokens,[1]}) of
-		      {ok,Ts,_} ->
-			  debug_print(Opts, "scan: ~p\n", [Ts]),
-			  {ok,St#luacomp{code=Ts}};
+	    Ret =
+          case io:request(F, {get_until,unicode,'',luerl_scan,tokens,[1]}) of
+              {ok,Ts,_} ->
+              debug_print(Opts, "scan: ~p\n", [Ts]),
+              {ok,St#luacomp{code=Ts}};
               {eof,_} -> {ok,St#luacomp{code=[]}};
-		      {error,E,_} -> {error,St#luacomp{errors=[E]}}
-		  end,
-	    file:close(F),
+              {error,E,_} -> {error,St#luacomp{errors=[E]}}
+          end,
+        file:close(F),
 	    Ret;
 	{error,E} -> {error,St#luacomp{errors=[{none,file,E}]}}
     end.

--- a/test/luerl_return_SUITE_data/only_comments.lua
+++ b/test/luerl_return_SUITE_data/only_comments.lua
@@ -1,0 +1,1 @@
+-- No code, just comments

--- a/test/luerl_tests.erl
+++ b/test/luerl_tests.erl
@@ -50,3 +50,7 @@ private_test() ->
     ?assertException(error, {badkey, missing}, luerl:get_private(missing, State2)),
     State3 = luerl:delete_private(secret, State2),
     ?assertException(error, {badkey, secret}, luerl:get_private(secret, State3)).
+
+loadfile_only_comments_test() ->
+    State1 = luerl:init(),
+    ?assertMatch({ok, _, _}, luerl:loadfile("./test/luerl_return_SUITE_data/only_comments.lua", State1)).


### PR DESCRIPTION
Previously, files only containing comments would throw an error. We now match on this situation and treat it as empty.