### PR TITLE
fix: wrap luerl:get_private in ok/error tuple

### DIFF
--- a/src/Elixir.Luerl.erl
+++ b/src/Elixir.Luerl.erl
@@ -190,7 +190,13 @@ put_private(St, K, V) ->
     luerl:put_private(K, V, St).
 
 get_private(St, Key) ->
-    maps:get(Key, St#luerl.private, nil).
+    try
+        {ok, maps:get(Key, St#luerl.private)}
+    catch
+        error:{badkey, _} ->
+            error
+    end.
+
 
 delete_private(St, K) ->
     try

--- a/test/Elixir.Luerl_tests.erl
+++ b/test/Elixir.Luerl_tests.erl
@@ -19,7 +19,7 @@
 private_test() ->
     State1 = 'Elixir.Luerl':init(),
     State2 = 'Elixir.Luerl':put_private(State1, secret, <<"mysecret">>),
-    ?assertMatch(<<"mysecret">>, 'Elixir.Luerl':get_private(State2, secret)),
-    ?assertMatch(nil, 'Elixir.Luerl':get_private(State2, missing)),
+    ?assertMatch({ok, <<"mysecret">>}, 'Elixir.Luerl':get_private(State2, secret)),
+    ?assertMatch(error, 'Elixir.Luerl':get_private(State2, missing)),
     State3 = 'Elixir.Luerl':delete_private(State2, secret),
-    ?assertMatch(nil, 'Elixir.Luerl':get_private(State3, secret)).
+    ?assertMatch(error, 'Elixir.Luerl':get_private(State3, secret)).


### PR DESCRIPTION
@rvirding had previously asked me to change this so that you can differentiate between a missing key and a key with a nil value.