### PR TITLE
feat: add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `luerl:get_private` returns `{ok, Val}` `error` tuple
+- `luerl:get_private` returns `{ok, Val} | error` tuple
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- `luerl:get_private` returns `{ok, Val}` `error` tuple
+
+### Fixed
+
+- files with only comments can now be loaded
+- atoms are now decoded as strings
+
+
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/rvirding/luerl/compare/v1.2.3...v1.3.0
+[1.2.3]: https://github.com/rvirding/luerl/compare/v1.2.2...v1.2.3

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,7 @@
 
 {ex_doc, [
     {source_url, <<"https://github.com/rvirding/luerl">>},
-    {extras, ["README.md", "LICENSE"]},
+    {extras, ["README.md", "CHANGELOG.md", "LICENSE"]},
     {main, "readme"},
     {skip_undefined_reference_warnings_on, ["luerl_parse", "luerl_scan"]},
     {groups_for_modules, [


### PR DESCRIPTION
Beyond tags, we should also tag a release for every new version of Luerl (and move this to Github actions!)

Follows the conventions from https://keepachangelog.com/en/1.1.0/

Closes #178

![Screenshot 2025-04-24 at 10 40 08 AM](https://github.com/user-attachments/assets/8a23680a-3e5b-436c-9bf9-bc3008d5659a)
