### PR TITLE
fix: allow called functions to propagate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - files with only comments can now be loaded
 - atoms are now decoded as strings
+- Erlang functions that return errors are now properly propagated upward and state is updated
 
 
 [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.4.0...HEAD

--- a/src/luerl_emul.erl
+++ b/src/luerl_emul.erl
@@ -796,6 +796,8 @@ call_erlfunc(Func, Args, Stk, Cs0, #luerl{stk=Stk0}=St0) ->
         {Ret,St1} when is_list(Ret) ->
             [#call_frame{is=Is,cont=Cont,lvs=Lvs,env=Env}|Cs1] = Cs0,
             emul(Is, Cont, Lvs, [Ret|Stk], Env, Cs1, St1#luerl{stk=Stk0,cs=Cs1});
+        {lua_error, Reason, St1} ->
+            lua_error(Reason, St1);
         _Other ->
             %% Don't include the erl_func in the call stack.
             lua_error(illegal_return_value, St0#luerl{stk=Stk0,cs=tl(Cs0)})
@@ -812,7 +814,9 @@ call_erlmfa({M,F,A}, Args, Stk, Cs0, #luerl{stk=Stk0}=St0) ->
         {Ret,St1} when is_list(Ret) ->
             [#call_frame{is=Is,cont=Cont,lvs=Lvs,env=Env}|Cs1] = Cs0,
             emul(Is, Cont, Lvs, [Ret|Stk], Env, Cs1, St1#luerl{stk=Stk0,cs=Cs1});
-        _Other ->
+        {lua_error, Reason, St1} ->
+            lua_error(Reason, St1);
+        Other ->
             %% Don't include the erl_func in the call stack.
             lua_error(illegal_return_value, St0#luerl{stk=Stk0,cs=tl(Cs0)})
     end.

--- a/src/luerl_emul.erl
+++ b/src/luerl_emul.erl
@@ -816,7 +816,7 @@ call_erlmfa({M,F,A}, Args, Stk, Cs0, #luerl{stk=Stk0}=St0) ->
             emul(Is, Cont, Lvs, [Ret|Stk], Env, Cs1, St1#luerl{stk=Stk0,cs=Cs1});
         {lua_error, Reason, St1} ->
             lua_error(Reason, St1);
-        Other ->
+        _Other ->
             %% Don't include the erl_func in the call stack.
             lua_error(illegal_return_value, St0#luerl{stk=Stk0,cs=tl(Cs0)})
     end.


### PR DESCRIPTION
Prior to this PR, any errors returned by Erlang functions would be replaced by an `illegal_return_value` error.

Worse, any global state that was updated from the function was thrown away. We now return the error and make sure the state is updated