### PR TITLE
fix: pcall handle binary error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `luerl:get_private` returns `{ok, Val} | error` tuple
+- (breaking) `luerl:get_private` returns `{ok, Val} | error` tuple
 
 ### Fixed
 
 - files with only comments can now be loaded
 - atoms are now decoded as strings
 - Erlang functions that return errors are now properly propagated upward and state is updated
+- binary error messages captured in pcall are not formatted
 
 
 [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.4.0...HEAD

--- a/src/luerl_lib.erl
+++ b/src/luerl_lib.erl
@@ -113,6 +113,9 @@ format_error({error_message,Msg}) ->
 %% Error is called.
 format_error({error_call,Args}) ->
     format_error_call(Args);
+%% binary is passed, we treat as an error message
+format_error(Binary) when is_binary(Binary) ->
+    <<Binary/binary, "!">>;
 %% Everything we don't recognise or know about.
 format_error(Error) ->
     unicode:characters_to_binary(io_lib:format(<<"~w!">>, [Error])).

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -424,7 +424,7 @@ pcall(_, [F|As], St0) ->
             {[false,Msg],St2};
         error:{lua_error,E,St2} ->
             %% Basic formatting for now.
-            Msg = unicode:characters_to_binary(luerl_lib:format_error(E)),
+            Msg = luerl_lib:format_error(E),
             {[false,Msg],St2}
     end.
 

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -423,7 +423,6 @@ pcall(_, [F|As], St0) ->
                   end,
             {[false,Msg],St2};
         error:{lua_error,E,St2} ->
-            %% Basic formatting for now.
             Msg = luerl_lib:format_error(E),
             {[false,Msg],St2}
     end.

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -69,6 +69,16 @@ external_error_test() ->
     ?assertEqual(Success, false),
     ?assertEqual(Message, <<"whoopsie">>).
 
+pcall_error_test() ->
+    State = luerl:init(),
+    F = fun([Message], S) ->
+                lua_error(Message, S)
+        end,
+    {ok, State1} = luerl:set_table_keys_dec([<<"foo">>], F, State),
+    ?assertMatch({lua_error, <<"one">>, _State}, luerl:call_function_dec([foo], [<<"one">>], State1)),
+    ?assertMatch({lua_error, <<"two">>, _State}, luerl:do(<<"return foo(\"two\")">>, State1)),
+    ?assertMatch({ok, [false, <<"three!">>], _State}, luerl:do(<<"return pcall(function()\nreturn foo(\"three\")\nend)\n">>, State1)).
+
 bad_return_value_test() ->
     State = luerl:init(),
     F = fun(_Args, S) ->


### PR DESCRIPTION
Prior to this, we were converting binaries to strings which would present them as something like `<<"<<116,104,114,101,101>>!">>`

This PR changes the formatting so if `lua_error(<<"binary">>)` will pass the binary through without trying to cast it to any value

Closes #164 