### PR TITLE
Add Dialyzer to CI, clean up a few warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,14 @@ jobs:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
       - run: rebar3 do eunit, ct --cover, cover
+
+  dialyzer:
+    name: Run Dialyzer
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "latest"
+          rebar3-version: "latest"
+      - run: rebar3 dialyzer

--- a/src/Elixir.Luerl.Old.erl
+++ b/src/Elixir.Luerl.Old.erl
@@ -168,7 +168,7 @@ decode(St, V) ->
     luerl_old:decode(V, St).
 
 externalize(St) ->
-    luerl_old_new:externalize(St).
+    luerl_old:externalize(St).
 
 internalize(St) ->
-    luerl_old_new:internalize(St).
+    luerl_old:internalize(St).

--- a/src/luerl_lib.erl
+++ b/src/luerl_lib.erl
@@ -45,6 +45,8 @@
 
 -export([conv_list/2,conv_list/3]).
 
+-dialyzer({[no_return], [lua_error/2, badarg_error/3, badarith_error/3]}).
+
 -spec lua_error(_,_) -> no_return().
 -spec badarg_error(_,_,_) -> no_return().
 


### PR DESCRIPTION
This PR adds Dialyzer to the GitHub Actions workflow. I have made it a separate step from the test matrix, using the latest tools. Let me know if you want to do something different and I'll change it.

I have also tried to clean up any existing Dialyzer warnings so the tests run clean: 
* Removed a reference to a nonexistent 'luerl_old_new' module
* Suppress Dialyzer warnings for `lua_error/2`, `badarg_error/3`, `badarith_error/3` since these functions appear to intentionally lack a return. 