### PR TITLE
Improve the handling of strings

### DIFF
--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -165,7 +165,7 @@ file_passes() ->				%Reading from file
 list_passes() ->				%Scanning string
     [{do,fun do_scan_string/1},
      {when_flag,to_scan,{done,fun(St) -> {ok,St} end}},
-     {do,fun do_parse/1}|
+     {do,fun do_parse/1} |
      chunk_passes()].
 
 chunk_passes() ->				%Doing the chunk
@@ -225,7 +225,7 @@ do_passes([], St) -> {ok,St}.
 
 do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
     %% Read the bytes in a file skipping an initial # line or Windows BOM.
-    case file:open(Name, [read,{encoding,unicode}]) of
+    case file:open(Name, [read,{encoding,latin1}]) of
 	{ok,F} ->
 	    %% Check if first line a script or Windows BOM, if so skip it.
 	    case io:get_line(F, '') of
@@ -236,7 +236,7 @@ do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
 	    end,
 	    %% Now read the file.
 	    Ret =
-          case io:request(F, {get_until,unicode,'',luerl_scan,tokens,[1]}) of
+          case io:request(F, {get_until,latin1,'',luerl_scan,tokens,[1]}) of
               {ok,Ts,_} ->
                   debug_print(Opts, "scan: ~p\n", [Ts]),
                   {ok,St#luacomp{code=Ts}};

--- a/src/luerl_comp_normalise.erl
+++ b/src/luerl_comp_normalise.erl
@@ -99,6 +99,9 @@ var({'.',L,Exp,Rest}, St0) ->
     {Ce,St1} = prefixexp_first(Exp, St0),
     {Cr,St2} = var_rest(Rest, St1),
     {dot(L, Ce, Cr),St2};
+var({{'NAME',L,N},_Attrib}, St) ->
+    %% Fro now we ignore attributes.
+    {var_name(L, N),St};
 var({'NAME',L,N}, St) -> {var_name(L, N),St}.
 
 var_rest({'.',L,Exp,Rest}, St0) ->

--- a/src/luerl_lib.erl
+++ b/src/luerl_lib.erl
@@ -425,8 +425,8 @@ tostring_tag(#erl_mfa{m=M,f=F}, Name) ->      %Erlang MFA triplets
     iolist_to_binary([Tag,io_lib:write_atom(M),<<":">>,io_lib:write_atom(F)]);
 tostring_tag(#thread{}, Name) ->
     get_tag(Name, <<"thread">>);
-tostring_tag(_, Name) ->
-    get_tag(Name, <<"unknown">>).
+tostring_tag(_, _Name) ->
+    <<"unknown">>.
 
 get_tag(Name, Type) ->
     if is_binary(Name) -> <<Name/binary,": ">>;

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -205,12 +205,25 @@ next_key(K, Dict, St) ->
 
 print(_, Args, St0) ->
     St1 = lists:foldl(fun (A, S0) ->
-			      {Str,S1} = luerl_lib:tostring(A, S0),
-			      io:format("~ts ", [Str]),
-			      S1
-		      end, St0, Args),
+                              {Str,S1} = luerl_lib:tostring(A, S0),
+                              print_arg(Str),
+                              S1
+                      end, St0, Args),
     io:nl(),
     {[],St1}.
+
+print_arg(Str) ->
+    Fun = fun (C, Acc) when C >= 128 ->
+                  [$?|Acc];                     %Just mark with a ?
+              %% Some special case control characters.
+              (C, Acc) when
+                    C =:= $\t ; C =:= $\n ; C =:= $\v ; C =:= $\f ; C =:= $\r ->
+                  [C|Acc];
+              (C, Acc) when C =< 31 -> Acc;     %Skip other control characters
+              (C, Acc) -> [C|Acc]               %Output the rest
+          end,
+    Chars = lists:foldr(Fun, [], binary_to_list(Str)),
+    io:format("~s ", [Chars]).
 
 print(Args, St0) -> print(nil, Args, St0).
 

--- a/src/luerl_lib_string.erl
+++ b/src/luerl_lib_string.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2013-2021 Robert Virding
+%% Copyright (c) 2013-2025 Robert Virding
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -160,18 +160,21 @@ do_find(S, L, Pat0, I, false) ->		%Pattern search string
 	{error,E} -> throw({error,E})
     end.
 
-%% format(Format, ...) -> [String].
+%% format([Format|Args], State) -> {[String],State}.
 %%  Format a string. All errors are badarg errors.
 %%  Do all the work in luerl_string_format but generate errors here.
 
 format(_, [F|As], St0) ->
     try
+	%% io:format("format ~w\n", [element(1,luerl_lib_string_format:format(F, As, St0))]),
 	luerl_lib_string_format:format(F, As, St0)
     catch
-	%% If we have a specific error, default is badarg.
+	%% If we have no specific error, default is badarg.
 	throw:{error,E,St1} -> lua_error(E, St1);
 	throw:{error,E} -> lua_error(E, St0);
 	_:_ -> badarg_error(format, [F|As], St0)
+        %% ?CATCH(C, E, Stack)
+        %%     error({C,E,Stack})
     end;
 format(_, As, St) -> badarg_error(format, As, St).
 

--- a/src/luerl_lib_string.erl
+++ b/src/luerl_lib_string.erl
@@ -102,8 +102,14 @@ char(_, As, St) ->
     case luerl_lib:args_to_integers(As) of
 	error -> badarg_error(char, As, St);
 	Bs ->
-	    String = list_to_binary(Bs),
-	    {[String],St}
+            %% Errors here also become lua_error.
+            try
+                String = list_to_binary(Bs),
+                {[String],St}
+            catch
+                _:_ ->
+                    badarg_error(char, As, St)
+            end
     end.
 
 %% dump(Function) -> String.

--- a/src/luerl_parse.yrl
+++ b/src/luerl_parse.yrl
@@ -30,6 +30,7 @@ Nonterminals
 chunk block stats stat semi retstat label_stat
 while_stat repeat_stat if_stat if_elseif if_else for_stat local_decl
 funcname dottedname varlist var namelist
+attrib attname attnamelist
 explist exp prefixexp args
 functioncall
 functiondef funcbody parlist
@@ -129,8 +130,8 @@ funcname -> dottedname : '$1' .
 
 local_decl -> function NAME funcbody :
 		  functiondef(line('$1'),'$2','$3') .
-local_decl -> namelist : {assign,line(hd('$1')),'$1',[]} .
-local_decl -> namelist '=' explist : {assign,line('$2'),'$1','$3'} .
+local_decl -> attnamelist : {assign,line(hd('$1')),'$1',[]} .
+local_decl -> attnamelist '=' explist : {assign,line('$2'),'$1','$3'} .
 
 dottedname -> NAME : '$1'.
 dottedname -> dottedname '.' NAME : dot_append(line('$2'), '$1', '$3') . 
@@ -145,6 +146,14 @@ var -> prefixexp '.' NAME : dot_append(line('$2'), '$1', '$3') .
 
 namelist -> NAME : ['$1'] .
 namelist -> namelist ',' NAME : '$1' ++ ['$3'] .
+
+attnamelist -> attname : ['$1'] .
+attnamelist -> attnamelist ',' attname : '$1' ++ ['$3'] .
+
+attname -> NAME : '$1'.
+attname -> NAME attrib : {'$1','$2'}.
+
+attrib -> '<' NAME '>' : {attrib,line('$2'),'$2'}.
 
 explist -> exp : ['$1'] .
 explist -> explist ',' exp : '$1' ++ ['$3'] .

--- a/src/luerl_scan.xrl
+++ b/src/luerl_scan.xrl
@@ -148,9 +148,14 @@ Erlang code.
 
 %% Luerl definitions of these types.
 -define(WHITE_SPACE(C), (C >= $\000 andalso C =< $\s)).
--define(DIGIT(C), (C >= $0 andalso C =< $9)).
--define(CHAR(C), (C >= O andalso C < 16#110000)).
+-define(UPPER(C), (C >= $A andalso C =< $Z)).
+-define(LOWER(C), (C >= $a andalso C =< $z)).
 -define(ASCII(C), (C >= 0 andalso C =< 127)).
+-define(DIGIT(C), (C >= $0 andalso C =< $9)).
+-define(HEX(C), (C >= $A andalso C =< $F orelse
+                 C >= $a andalso C =< $f orelse
+                 ?DIGIT(C))).
+-define(CHAR(C), (C >= O andalso C < 16#110000)).
 -define(UNICODE(C),
         (is_integer(C) andalso
          (C >= 0 andalso C < 16#D800 orelse
@@ -259,17 +264,8 @@ string_chars([$\\ | Cs], Acc) ->
     string_bq_chars(Cs, Acc);
 string_chars([$\n | _], _Acc) ->
     throw(string_error);
-string_chars([C0 | Cs], Acc) ->
-    C1 = if ?ASCII(C0) -> C0;
-            true ->
-                 case unicode:characters_to_binary([C0]) of
-                     Bin when is_binary(Bin) ->
-                         Bin;
-                     _Error ->
-                         throw(string_error)
-                 end
-         end,
-    string_chars(Cs, [C1|Acc]);
+string_chars([C | Cs], Acc) ->
+    string_chars(Cs, [C | Acc]);
 string_chars([], Acc) ->
     lists:reverse(Acc).
 
@@ -277,24 +273,19 @@ string_chars([], Acc) ->
 %%  Handle the backquotes characters. These always fit directly into
 %%  one byte and are never UTF-8 encoded.
 
-string_bq_chars([C1|Cs0], Acc) when C1 >= $0, C1 =< $9 ->   %1-3 decimal digits
+string_bq_chars([C1|Cs0], Acc) when ?DIGIT(C1) -> %1-3 decimal digits
     I1 = C1 - $0,
+    %% Note here we "export" Byte and Cs1 (this is Erlang).
     case Cs0 of
-        [C2|Cs1] when C2 >= $0, C2 =< $9 ->
-            I2 = C2 - $0,
-            case Cs1 of
-                [C3|Cs2] when C3 >= $0, C3 =< $9 ->
-                    I3 = C3 - $0,
-                    Byte = 100*I1 + 10*I2 + I3,
-                    %% Must fit into one byte!
-                    (Byte =< 255) orelse throw(string_error),
-                    string_chars(Cs2, [Byte|Acc]);
-                _ ->
-                    Byte = 10*I1 + I2,
-                    string_chars(Cs1, [Byte|Acc])
-            end;
-        _ -> string_chars(Cs0, [I1|Acc])
-    end;
+        [C2,C3|Cs1] when ?DIGIT(C2), ?DIGIT(C3) ->
+            Byte = 100 * I1 + 10 * (C2 - $0) + (C3 - $0),
+            (Byte =< 255) orelse throw(string_error);
+        [C2|Cs1] when ?DIGIT(C2)  ->
+            Byte = 10 * I1 + (C2 - $0);
+        Cs1 ->
+            Byte = I1
+    end,
+    string_chars(Cs1, [Byte | Acc]);
 string_bq_chars([$x,C1,C2|Cs], Acc) ->          %2 hex digits
     case hex_char(C1) and hex_char(C2) of
         true ->
@@ -302,6 +293,8 @@ string_bq_chars([$x,C1,C2|Cs], Acc) ->          %2 hex digits
             string_chars(Cs, [Byte|Acc]);
         false -> throw(string_error)
     end;
+string_bq_chars([$u,${|Cs], Acc) ->             %Explicit utf-8 character
+    string_bq_chars_utf8(Cs, Acc);
 string_bq_chars([$z|Cs], Acc) ->                %Skip whitespace
     string_chars(skip_space(Cs), Acc);
 string_bq_chars([C|Cs], Acc) ->
@@ -311,6 +304,20 @@ string_bq_chars([C|Cs], Acc) ->
     end;
 string_bq_chars([], Acc) ->
     Acc.
+
+string_bq_chars_utf8(Cs0, Acc) ->
+    case lists:splitwith(fun (C) -> ?HEX(C) end, Cs0) of
+        {Hcs,"}" ++ Cs1} when Hcs =/= [] ->
+            Hex = list_to_integer(Hcs, 16),
+            case unicode:characters_to_binary([Hex]) of
+                HexBin when is_binary(HexBin) ->
+                    string_chars(Cs1, [HexBin | Acc]);
+                _Error ->
+                    throw(string_error)
+            end;
+        _Error ->
+            throw(string_error)
+    end.
 
 skip_space([C|Cs]) when C >= 0, C =< $\s -> skip_space(Cs);
 skip_space(Cs) -> Cs.
@@ -326,25 +333,13 @@ long_string_token(Cs0, Len, BrLen, Line) ->
         Cs1 -> Cs1
     end,
     try
-        Bytes = long_string_chars(Cs1, []),
+        Bytes = Cs1,                            %The bytes are just the chars.
         String = iolist_to_binary(Bytes),
         {token,{'LITERALSTRING',Line,String}}
     catch
         _:_ ->
             {error,"illegal string"}
     end.
-
-long_string_chars([C | Cs], Acc) when ?ASCII(C) ->
-    long_string_chars(Cs, [C|Acc]);
-long_string_chars([C | Cs], Acc) ->             %This could be unicode
-    case unicode:characters_to_binary([C]) of
-        Bin when is_binary(Bin) ->
-            long_string_chars(Cs, [Bin|Acc]);
-        _Error ->
-            throw(string_error)
-    end;
-long_string_chars([], Acc) ->
-    lists:reverse(Acc).
 
 hex_char(C) when C >= $0, C =< $9 -> true;
 hex_char(C) when C >= $a, C =< $f -> true;
@@ -362,9 +357,11 @@ escape_char($n) -> $\n;                         %\n = LF
 escape_char($r) -> $\r;                         %\r = CR
 escape_char($t) -> $\t;                         %\t = TAB
 escape_char($v) -> $\v;                         %\v = VT
-escape_char($\\) -> $\\;                        %\e = BACKSLASH
-escape_char($") -> $";                          %\s = SPC
-escape_char($') -> $';                          %\d = DEL
+escape_char($\\) -> $\\;                        %\\ = BACKSLASH
+escape_char($") -> $";                          %\" = STRING QUOTE
+escape_char($') -> $';                          %\' = STRING QUOTE
+escape_char($\n) -> $\n;                        %\LF = LF
+escape_char($\r) -> $\n;                        %\RET = LF
 escape_char(_C) -> error.                       %Illegal
 
 %% is_keyword(Name) -> boolean().


### PR DESCRIPTION
Here we fix the handling of strings in the `string` module. It behaves as it should but the formatting of some numerical output strings, while it is correct, does not quite look the same as the Lua module. This is because the Lua implementation uses C libraries while Luerl uses Erlang libraries.