### PR TITLE
Improve the scanner and fix the parser

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -24,7 +24,16 @@
 Luerl is an implementation of Lua 5.3 written in Erlang.
 This is the main public API module for interfacing with Luerl.
 
-The `LuaState` parameter is the state of a Lua VM instance. It must be created with the `init/0` call and be carried from one call to the next.
+The `LuaState` parameter is the state of a Lua VM instance. It must be created with the `init/0` call and be threaded from one call to the next.
+
+Note that Luerl, following Lua, does do any implicit UTF-8 encoding of input strings. This means that all strings given as arguments to the calls or the strings to evaluate with `do/3` or `do_dec/3` need to have already been UTF-8 encoded. This can be quite easily do with the `~` or `~b` sigils. For example
+
+`luerl:do(~b\"return 'árvíztűrő tükörfúrógép'\", St0)`
+
+or
+
+`luerl:do(~\"return 'árvíztűrő tükörfúrógép'\", St0)`
+
 """).
 
 %% ?MODULEDOC( #{group => <<"Trace Control functions">>} ).

--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -12,31 +12,36 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
-%% File    : luerl_new.erl
+%% File    : luerl.erl
 %% Authors : Robert Virding
-%% Purpose : The new basic LUA 5.3 interface.
+%% Purpose : The basic LUA 5.4 interface.
 
 -module(luerl).
 
 -include("luerl.hrl").
 
-?MODULEDOC( """
-Luerl is an implementation of Lua 5.3 written in Erlang.
+%% Use normal strings as it is easier to use " and make it readable
+%% with both old and new string parsing.
+
+?MODULEDOC(
+"Luerl is an implementation of Lua 5.3 written in Erlang.
 This is the main public API module for interfacing with Luerl.
 
-The `LuaState` parameter is the state of a Lua VM instance. It must be created with the `init/0` call and be threaded from one call to the next.
+The `LuaState` parameter is the state of a Lua VM instance. It must be
+created with the `init/0` call and be threaded from one call to the
+next.
 
-Note that Luerl, following Lua, does do any implicit UTF-8 encoding of input strings. This means that all strings given as arguments to the calls or the strings to evaluate with `do/3` or `do_dec/3` need to have already been UTF-8 encoded. This can be quite easily do with the `~` or `~b` sigils. For example
+Note that Luerl, following Lua, does do any implicit UTF-8 encoding of
+input strings. This means that all strings given as arguments to the
+calls or the strings to evaluate with `do/3` or `do_dec/3` need to
+have already been UTF-8 encoded. This can be quite easily do with the
+`~` or `~b` sigils. For example
 
 `luerl:do(~b\"return 'árvíztűrő tükörfúrógép'\", St0)`
 
 or
 
-`luerl:do(~\"return 'árvíztűrő tükörfúrógép'\", St0)`
-
-""").
-
-%% ?MODULEDOC( #{group => <<"Trace Control functions">>} ).
+`luerl:do(~\"return 'árvíztűrő tükörfúrógép'\", St0)`").
 
 %% Basic user API to luerl.
 -export([init/0,gc/1,
@@ -971,8 +976,14 @@ decode_erlmfa(#erl_mfa{m=Mod,f=Func,a=Arg}=_Mfa, _St, _In) ->
 %% can be stored externally or can be recreated from external storage.
 %% Currently very simple: only random state needs special treatment.
 
+-spec externalize(LuaState) -> LuaState when
+      LuaState :: luerlstate().
+
 externalize(S) ->
     luerl_lib_math:externalize(S).
+
+-spec internalize(LuaState) -> LuaState when
+      LuaState :: luerlstate().
 
 internalize(S) ->
     luerl_lib_math:internalize(S).

--- a/src/luerl_comp.erl
+++ b/src/luerl_comp.erl
@@ -224,30 +224,14 @@ do_passes([], St) -> {ok,St}.
 %%  The actual compiler passes.
 
 do_scan_file(#luacomp{lfile=Name,opts=Opts}=St) ->
-    %% Read the bytes in a file skipping an initial # line or Windows BOM.
-    case file:open(Name, [read,{encoding,latin1}]) of
-	{ok,F} ->
-	    %% Check if first line a script or Windows BOM, if so skip it.
-	    case io:get_line(F, '') of
-		"#" ++ _ -> ok;			%Skip line
-		[239,187,191|_] ->
-		    file:position(F, 3);	%Skip BOM
-		_ -> file:position(F, bof)	%Get it all
-	    end,
-	    %% Now read the file.
-	    Ret =
-          case io:request(F, {get_until,latin1,'',luerl_scan,tokens,[1]}) of
-              {ok,Ts,_} ->
-                  debug_print(Opts, "scan: ~p\n", [Ts]),
-                  {ok,St#luacomp{code=Ts}};
-              {eof,_} ->
-                  {ok,St#luacomp{code=[]}};
-              {error,E,_} ->
-                  {error,St#luacomp{errors=[E]}}
-          end,
-        file:close(F),
-	    Ret;
-	{error,E} -> {error,St#luacomp{errors=[{none,file,E}]}}
+    case luerl_io:scan_file(Name, 1) of
+        {ok,Ts} ->
+            debug_print(Opts, "scan: ~p\n", [Ts]),
+            {ok,St#luacomp{code=Ts}};
+        {eof,_} ->
+            {ok,St#luacomp{code=[]}};
+        {error,E} ->
+            {error,St#luacomp{errors=[E]}}
     end.
 
 do_scan_string(#luacomp{code=Str,opts=Opts}=St) ->

--- a/src/luerl_io.erl
+++ b/src/luerl_io.erl
@@ -1,0 +1,147 @@
+%% Copyright (c) 2025 Robert Virding
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% File    : luerl_io.erl
+%% Author  : Robert Virding
+%% Purpose : Some basic i/o functions for Luerl.
+
+-module(luerl_io).
+
+-include("luerl.hrl").
+
+?MODULEDOC( """
+This module provides a standard of set io functions for Luerl. In the
+following description, many functions have an optional parameter
+`IoDevice`. If included, it must be the pid of a process which handles
+the IO protocols such as the IoDevice returned by `file:open/2`. Also
+in the functions handling files it can also be the name of the file
+which will then be opened.
+
+Note that Luerl, following Lua, does do any implicit UTF-8 encoding of
+input strings.
+
+""").
+
+-export([get_line/0,get_line/1,get_line/2,collect_line/2]).
+-export([scan_file/1,scan_file/2,parse_file/1,parse_file/2]).
+
+%% get_line() -> Data | {error,Error} | eof.
+%%  Reads a line from the standard input (IoDevice), prompting it with
+%%  Prompt. Doing it this way saves the input in history. We also make
+%%  sure that any utf-8 encoding is done before we return the data.
+
+?DOC( #{equiv => get_line(standard_io, '')}).
+
+get_line() ->
+    get_line(standard_io, '').
+
+?DOC( #{equiv => get_line(standard_io, Prompt)}).
+ 
+get_line(Prompt) ->
+    get_line(standard_io, Prompt).
+
+?DOC( """
+Read a line of text from `IoDevice` withe the prompt `Prompt`. We make
+sure that anu UTF-8 encoding is done before we return the data.
+""").
+
+get_line(IoDevice, Prompt) ->
+    Get = io:request(IoDevice,
+                     {get_until,latin1,Prompt,luerl_io,collect_line,[]}),
+    %% Make sure unicode codepoints ahve been expanded.
+    case Get of
+        Line when is_list(Line) ->
+            unicode:characters_to_binary(Line);
+        Other -> Other
+    end.
+
+%% collect_line(OldStack, Data) -> {done,Result,Rest} | {more,NewStack}.
+
+collect_line(Stack, Data) ->
+    case io_lib:collect_line(start, Data, latin1, ignored) of
+        {stop,Result,Rest} ->
+            {done,lists:reverse(Stack, Result),Rest};
+        MoreStack ->
+            {more,MoreStack ++ Stack}
+    end.
+
+%% scan_file(FileName|Fd) -> {ok,[Token]} | {error,Error}.
+%% scan_file(FileName|Fd, Line) -> {ok,[Token]} | {error,Error}.
+%%  Scan a file returning the tokens found in the file. Handle errors
+%%  consistently.
+
+?DOC( #{equiv => scan_file(FileName, 1)}).
+
+scan_file(FileName) -> scan_file(FileName, 1).
+
+?DOC( """
+Scan the file `FileName` and return the tokens in it. `FileName` can
+also be an `IoDevice` of an already opened file.
+""").
+
+scan_file(FileName, Line) ->
+    with_token_file(FileName,
+                    fun (Ts, _LastLine) -> {ok,Ts} end,
+                    Line).
+
+%% parse_file(FileName|Fd) -> {ok,[{Sexpr,Line}]} | {error,Error}.
+%% parse_file(FileName|Fd, Line) -> {ok,[{Sexpr,Line}]} | {error,Error}.
+%%  Parse a file returning the chunk it contained. Handle errors
+%%  consistently.
+
+?DOC( #{equiv => parse_file(FileName, 1)}).
+
+parse_file(FileName) -> parse_file(FileName, 1).
+
+?DOC( """
+Parse the file `FileName` and return the chunk in it. `FileName` can
+also be an `IoDevice` of an already opened file.
+""").
+
+parse_file(FileName, Line) ->
+    with_token_file(FileName,
+                    fun (Ts, LastLine) -> parse_tokens(Ts, LastLine) end,
+                    Line).
+
+parse_tokens(Tokens, _LastLine) ->
+    luerl_parse:chunk(Tokens).
+
+%% with_token_file(FileName|Fd, DoFunc, Line)
+%%  Open the file, scan all Luerl tokens and apply DoFunc on them. Note
+%%  that a new file starts at line 1.
+
+with_token_file(Fd, Do, Line) when is_pid(Fd) ->
+    with_token_file_fd(Fd, Do, Line);
+with_token_file(Name, Do, _Line) ->
+    case file:open(Name, [read,{encoding,latin1}]) of
+        {ok,Fd} ->
+            %% Check if first line a script or Windows BOM, if so skip it.
+            case io:get_line(Fd, '') of
+                "#" ++ _ -> ok;                 %Skip line
+                [239,187,191|_] ->
+                    file:position(Fd, 3);       %Skip BOM
+                _ -> file:position(Fd, bof)     %Get it all
+            end,
+            with_token_file_fd(Fd, Do, 1);      %Start at first valid line
+        {error,Error} -> {error,{none,file,Error}}
+    end.
+
+with_token_file_fd(Fd, Do, Line) ->             %Called with a file descriptor
+    Ret = case io:request(Fd, {get_until,latin1,'',luerl_scan,tokens,[Line]}) of
+              {ok,Ts,LastLine} -> Do(Ts, LastLine);
+              {eof,_}=Eof -> Eof;               %This might occur.
+              {error,Error,_} -> {error,Error}
+          end,
+    file:close(Fd),                             %Close the file
+    Ret.                                        % and return value

--- a/src/luerl_parse.yrl
+++ b/src/luerl_parse.yrl
@@ -28,7 +28,8 @@ Expect 2.					%Suppress shift/reduce warning
 
 Nonterminals
 chunk block stats stat semi retstat label_stat
-while_stat repeat_stat if_stat if_elseif if_else for_stat local_decl
+while_stat repeat_stat if_stat if_elseif if_else for_stat func_stat
+local_stat local_decl
 funcname dottedname varlist var namelist
 attrib attname attnamelist
 explist exp prefixexp args
@@ -40,8 +41,8 @@ binop unop uminus.
 Terminals
 NAME NUMERAL LITERALSTRING
 
-'and' 'break' 'do' 'else' 'elseif' 'end' 'false' 'for' 'function' 'goto' 'if' 
-'in' 'local' 'nil' 'not' 'or' 'repeat' 'return' 'then' 'true' 'until' 'while' 
+'and' 'break' 'do' 'else' 'elseif' 'end' 'false' 'for' 'function' 'goto' 'if'
+'in' 'local' 'nil' 'not' 'or' 'repeat' 'return' 'then' 'true' 'until' 'while'
 
 '+' '-' '*' '/' '//' '%' '^' '&' '|' '~' '>>' '<<' '#'
 '==' '~=' '<=' '>=' '<' '>' '='
@@ -72,12 +73,6 @@ chunk -> block : '$1'  .
 block -> stats : '$1' .
 block -> stats retstat : '$1' ++ ['$2'] .
 
-retstat -> return semi : {return,line('$1'),[]} .
-retstat -> return explist semi : {return,line('$1'),'$2'} .
-
-semi -> ';' .					%semi is never returned
-semi -> '$empty' .
-
 stats -> '$empty' : [] .
 stats -> stats stat : '$1' ++ ['$2'] .
 
@@ -95,8 +90,31 @@ stat -> while_stat : '$1' .
 stat -> repeat_stat : '$1' .
 stat -> if_stat : '$1' .
 stat -> for_stat : '$1' .
-stat -> function funcname funcbody : functiondef(line('$1'),'$2','$3') .
-stat -> local local_decl : {local,line('$1'),'$2'} .
+stat -> func_stat : '$1' .
+stat -> local_stat : '$1' .
+%% stat -> local local_decl : {local,line('$1'),'$2'} .
+
+%% retstat ::= return [explist] [‘;’]
+
+retstat -> return semi : {return,line('$1'),[]} .
+retstat -> return explist semi : {return,line('$1'),'$2'} .
+
+semi -> ';' .					%semi is never returned
+semi -> '$empty' .
+
+%% attnamelist ::= Name attrib {‘,’ Name attrib}
+
+attnamelist -> attname : ['$1'] .
+attnamelist -> attnamelist ',' attname : '$1' ++ ['$3'] .
+
+attname -> NAME : '$1'.
+attname -> NAME attrib : {'$1','$2'}.
+
+%% attrib ::= [‘<’ Name ‘>’]
+
+attrib -> '<' NAME '>' : {attribute,line('$2'),'$2'}.
+
+%% label ::= ‘::’ Name ‘::’
 
 label_stat -> '::' NAME '::' : {label,line('$1'),'$2'} .
 
@@ -117,10 +135,15 @@ if_else -> '$empty' : [] .			%An empty block
 %% stat ::= for Name '=' exp ',' exp [',' exp] do block end
 %% stat ::= for namelist in explist do block end
 
-for_stat -> 'for' NAME '=' explist do block end : 
+for_stat -> 'for' NAME '=' explist do block end :
 	    numeric_for(line('$1'), '$2', '$4', '$6') .
 for_stat -> 'for' namelist 'in' explist 'do' block 'end' :
 	    generic_for(line('$1'), '$2', '$4', '$6') .
+
+%% stat ::= function funcname funcbody
+
+func_stat -> function funcname funcbody :
+                 functiondef(line('$1'),'$2','$3') .
 
 %% funcname ::= Name {'.' Name} [':' Name]
 
@@ -128,32 +151,37 @@ funcname -> dottedname ':' NAME :
 		dot_append(line('$2'), '$1', {method,line('$2'),'$3'}) .
 funcname -> dottedname : '$1' .
 
+%% stat ::= local function Name funcbody
+%% stat ::= local attnamelist [‘=’ explist]
+
+local_stat -> 'local' local_decl : {local,line('$1'),'$2'} .
+
 local_decl -> function NAME funcbody :
-		  functiondef(line('$1'),'$2','$3') .
+                  functiondef(line('$1'),'$2','$3') .
 local_decl -> attnamelist : {assign,line(hd('$1')),'$1',[]} .
 local_decl -> attnamelist '=' explist : {assign,line('$2'),'$1','$3'} .
 
 dottedname -> NAME : '$1'.
-dottedname -> dottedname '.' NAME : dot_append(line('$2'), '$1', '$3') . 
+dottedname -> dottedname '.' NAME : dot_append(line('$2'), '$1', '$3') .
+
+%% varlist ::= var {‘,’ var}
 
 varlist -> var : ['$1'] .
 varlist -> varlist ',' var : '$1' ++ ['$3'] .
 
+%% var ::= Name | prefixexp ‘[’ exp ‘]’ | prefixexp ‘.’ Name
+
 var -> NAME : '$1' .
 var -> prefixexp '[' exp ']' :
 	   dot_append(line('$2'), '$1', {key_field,line('$2'),'$3'}) .
-var -> prefixexp '.' NAME : dot_append(line('$2'), '$1', '$3') . 
+var -> prefixexp '.' NAME : dot_append(line('$2'), '$1', '$3') .
+
+%% namelist ::= Name {‘,’ Name}
 
 namelist -> NAME : ['$1'] .
 namelist -> namelist ',' NAME : '$1' ++ ['$3'] .
 
-attnamelist -> attname : ['$1'] .
-attnamelist -> attnamelist ',' attname : '$1' ++ ['$3'] .
-
-attname -> NAME : '$1'.
-attname -> NAME attrib : {'$1','$2'}.
-
-attrib -> '<' NAME '>' : {attrib,line('$2'),'$2'}.
+%% explist ::= exp {‘,’ exp}
 
 explist -> exp : ['$1'] .
 explist -> explist ',' exp : '$1' ++ ['$3'] .
@@ -167,34 +195,50 @@ exp -> '...' : '$1' .
 exp -> functiondef : '$1' .
 exp -> prefixexp : '$1' .
 exp -> tableconstructor : '$1' .
-exp -> binop : '$1' . 
+exp -> binop : '$1' .
 exp -> unop : '$1' .
+
+%% prefixexp ::= var | functioncall | ‘(’ exp ‘)’
 
 prefixexp -> var : '$1' .
 prefixexp -> functioncall : '$1' .
 prefixexp -> '(' exp ')' : {single,line('$1'),'$2'} .
+
+%% functioncall ::= prefixexp args | prefixexp ‘:’ Name args
 
 functioncall -> prefixexp args :
 		    dot_append(line('$1'), '$1', {functioncall,line('$1'), '$2'}) .
 functioncall -> prefixexp ':' NAME args :
 		    dot_append(line('$2'), '$1', {methodcall,line('$2'),'$3','$4'}) .
 
+%% args ::= ‘(’ [explist] ‘)’ | tableconstructor | LiteralString
+
 args -> '(' ')' : [] .
 args -> '(' explist ')' : '$2' .
 args -> tableconstructor : ['$1'] .		%Syntactic sugar
 args -> LITERALSTRING : ['$1'] .		%Syntactic sugar
 
+%% functiondef ::= function funcbody
+
 functiondef -> 'function' funcbody : functiondef(line('$1'), '$2').
+
+%% funcbody ::= ‘(’ [parlist] ‘)’ block end
 
 funcbody -> '(' ')' block 'end' : {[],'$3'} .
 funcbody -> '(' parlist ')' block 'end' : {'$2','$4'} .
+
+%% parlist ::= namelist [‘,’ ‘...’] | ‘...
 
 parlist -> namelist : '$1' .
 parlist -> namelist ',' '...' : '$1' ++ ['$3'] .
 parlist -> '...' : ['$1'] .
 
+%% tableconstructor ::= ‘{’ [fieldlist] ‘}’
+
 tableconstructor -> '{' '}' : {table,line('$1'),[]} .
 tableconstructor -> '{' fieldlist '}' : {table,line('$1'),'$2'} .
+
+%% fieldlist ::= field {fieldsep field} [fieldsep]
 
 fieldlist -> fields : '$1' .
 fieldlist -> fields fieldsep : '$1' .
@@ -202,12 +246,16 @@ fieldlist -> fields fieldsep : '$1' .
 fields ->  field : ['$1'] .
 fields ->  fields fieldsep field : '$1' ++ ['$3'] .
 
+%% field ::= ‘[’ exp ‘]’ ‘=’ exp | Name ‘=’ exp | exp
+
 field -> '[' exp ']' '=' exp : {key_field,line('$1'),'$2','$5'} .
 field -> NAME '=' exp : {name_field,line('$1'),'$1','$3'} .
 field -> exp : {exp_field,line('$1'),'$1'} .
 
 fieldsep -> ',' .
 fieldsep -> ';' .
+
+%% fieldsep ::= ‘,’ | ‘;’
 
 %% exp ::= exp binop exp
 %% exp ::= unop exp
@@ -239,7 +287,7 @@ unop -> 'not' exp : {op,line('$1'),cat('$1'),'$2'} .
 unop -> '#' exp : {op,line('$1'),cat('$1'),'$2'} .
 unop -> '~' exp : {op,line('$1'),cat('$1'),'$2'} .
 unop -> uminus : '$1' .
-     
+
 uminus -> '-' exp : {op,line('$1'),'-','$2'} .
 
 Erlang code.

--- a/src/luerl_scan.xrl
+++ b/src/luerl_scan.xrl
@@ -437,7 +437,7 @@ string_bq_chars_utf8([$}|Cs], Uchar, Acc) ->
 string_bq_chars_utf8(_Cs, _Uchar, _Acc) ->
     throw({string_error,"missing '}'"}).
 
-skip_space([C|Cs]) when C >= 0, C =< $\s -> skip_space(Cs);
+skip_space([$\s|Cs]) -> skip_space(Cs);
 skip_space(Cs) -> Cs.
 
 %% long_string_token(InputChars, Length, BracketLength, Line) ->

--- a/src/luerl_scan.xrl
+++ b/src/luerl_scan.xrl
@@ -23,54 +23,44 @@ D = [0-9]
 H = [0-9A-Fa-f]
 U = [A-Z]
 L = [a-z]
+NAME = ({U}|{L}|_|{D})
+SNAME = ({U}|{L}|_)
 
 Rules.
 
 %% Names/identifiers.
 ({U}|{L}|_)({U}|{L}|_|{D})* :
 	name_token(TokenChars, TokenLine).
-%% Numbers, we separately parse (Erlang) integers and floats.
-%% Integers.
-{D}+ : 
-	case catch {ok,list_to_integer(TokenChars)} of
-	    {ok,I} -> {token,{'NUMERAL',TokenLine,I}};
-	    _ -> {error,"illegal number"}
-	end.
-0[xX]{H}+ :
-        Int = list_to_integer(string:substr(TokenChars, 3), 16),
-        {token,{'NUMERAL',TokenLine,Int}}.
 
-%% Floats, we have separate rules to make them easier to handle.
-{D}+\.{D}+([eE][-+]?{D}+)? :
-	case catch {ok,list_to_float(TokenChars)} of
-	    {ok,F} -> {token,{'NUMERAL',TokenLine,F}};
-	    _ -> {error,"illegal number"}
-	end.
-{D}+[eE][-+]?{D}+ :
-	[M,E] = string:tokens(TokenChars, "eE"),
-	case catch {ok,list_to_float(M ++ ".0e" ++ E)} of
-	    {ok,F} -> {token,{'NUMERAL',TokenLine,F}};
-	    _ -> {error,"illegal number"}
-	end.
-{D}+\.([eE][-+]?{D}+)? :
-	[M|E] = string:tokens(TokenChars, "."),
-	case catch {ok,list_to_float(lists:append([M,".0"|E]))} of
-	    {ok,F} -> {token,{'NUMERAL',TokenLine,F}};
-	    _ -> {error,"illegal number"}
-	end.
-\.{D}+([eE][-+]?{D}+)? :
-	case catch {ok,list_to_float("0" ++ TokenChars)} of
-	    {ok,F} -> {token,{'NUMERAL',TokenLine,F}};
-	    _ -> {error,"illegal number"}
-	end.
+%% Numbers, we parse integers and floats in one go as they can
+%% interact with each other.
 
-%% Hexadecimal floats, we have one complex rule to handle bad formats
-%% more like the Lua parser.
+%% Hexadecimal numbers, we have separate rule to ensure we don't have
+%% just a '.'. NOTE THESE MUST COME FIRST TO CATCH 0[xX]!!!!
+%%
+%% 0[xX]{H}+\.?{H}+([pP][-+]?{D}+)?{NAME}* :
+%% 0[xX]{H}+\.?{H}*([pP][-+]?{D}+)?{NAME}* :
+%%
+%% 0[xX]{H}*\.{H}*([pP][-+]?{D}+)?{NAME}* :
 
-0[xX]{H}*\.?{H}*([pP][+-]?{D}+)? :
-	hex_float_token(TokenChars, TokenLine).
+0[xX]{H}*\.?{H}*([pP][-+]?{D}*)?{NAME}* :
+	io:format("h2 ~p\n", [TokenChars]),
+	hex_number_token(TokenChars, TokenLine).
 
-%% Strings. 
+%% Decimal numbers, we separate rules to ensure we don't have just a '.'.
+%% Both integers and floats are handled here.
+%%
+%% {D}*\.?{D}*([eE][-+]?{D}+)?{NAME}*
+%% (({D}+\.?{D*})|(\.{D}+))([eE][-+]?{D}+)?{NAME}* :
+
+\.{D}+([eE][-+]?{D}+)?{NAME}* :
+	%% io:format("d1 ~p\n", [TokenChars]),
+	decimal_number_token(TokenChars, TokenLine).
+{D}+\.?{D}*([eE][-+]?{D}+)?{NAME}* :
+	%% io:format("d2 ~p\n", [TokenChars]),
+	decimal_number_token(TokenChars, TokenLine).
+
+%% Strings.
 %% Handle the illegal newlines in string_token.
 \"(\\.|\\\n|[^"\\])*\" :
 	string_token(TokenChars, TokenLen, TokenLine).
@@ -148,8 +138,6 @@ Erlang code.
 
 %% Luerl definitions of these types.
 -define(WHITE_SPACE(C), (C >= $\000 andalso C =< $\s)).
--define(UPPER(C), (C >= $A andalso C =< $Z)).
--define(LOWER(C), (C >= $a andalso C =< $z)).
 -define(ASCII(C), (C >= 0 andalso C =< 127)).
 -define(DIGIT(C), (C >= $0 andalso C =< $9)).
 -define(HEX(C), (C >= $A andalso C =< $F orelse
@@ -181,73 +169,190 @@ name_token(Cs, L) ->
 name_string(Name) ->
     binary_to_atom(Name, latin1).               %Only latin1 in Lua
 
-%% hex_float_token(TokenChars, TokenLine) ->
+%% decimal_number_token(TokenChars, TokenLine)
 %%     {token,{'NUMERAL',TokenLine,Float}} | {error,E}.
-%%  Build a float form a hex float string.
+%%  Build either an integer or a float from a decimal number
+%%  string. We first collect the specific number section, then we
+%%  create the number. This makes it easier to keep track of which
+%%  sections we need to make Lua compliant Luerl numbers, as Lua has
+%%  some very "specific" handling.
+%%
+%%  \.{D}+([eE][-+]?{D}+)?{NAME}* :
+%%  {D}+\.?{D}*([eE][-+]?{D}+)?{NAME}* :
 
-hex_float_token(TokenChars, TokenLine) ->
-    Tcs = string:substr(TokenChars, 3),
-    case lists:splitwith(fun (C) -> (C =/= $p) and (C =/= $P) end, Tcs) of
-        {Mcs,[]} when Mcs /= [] ->
-            hex_float(Mcs, [], TokenLine);
-        {Mcs,[_P|Ecs]} when Ecs /= [] ->
-            hex_float(Mcs, Ecs, TokenLine);
-        _Other -> {error,"malformed number"}
+decimal_number_token(TokenChars, TokenLine) ->
+    io:format("dnt ~p\n", [dec_number_split(TokenChars)]),
+    Result = case dec_number_split(TokenChars) of
+                 %% If there is anything after the number sections then
+                 %% it is an error!
+                 {_,_,_,Rest} when Rest =/= [] -> error;
+                 {[],[],[],_Rest} -> error;     %Nothing at all
+                 {[],[],_Ecs,_Rest} -> error;   %No number data
+                 {[],".",_Ecs,_Rest} -> error;  %Only "empty" fraction
+                 {_,_,[_E],_Rest} -> error;     %Only "empty" exponent
+                 {Hcs,Fcs,Ecs,_Rest} ->
+                     DW = list_to_integer("0" ++ Hcs),
+                     io:format("dw ~p\n", [DW]),
+                     DF = dec_number_fraction(Fcs, DW),
+                     io:format("ff ~p\n", [DF]),
+                     Dnum = dec_number_exponent(Ecs, DF),
+                     io:format("dn ~p\n", [Dnum]),
+                     {ok,Dnum}
+             end,
+    case Result of
+        {ok,Number} ->
+            {token,{'NUMERAL',TokenLine,Number}};
+        error ->
+            number_token_error(TokenChars)
     end.
 
-%% hex_float(Mantissa, Exponent) -> {token,{'NUMERAL',Line,Float}} | {error,E}.
-%% hex_mantissa(Chars) -> {float,Float} | error.
-%% hex_fraction(Chars, Pow, SoFar) -> Fraction.
+number_token_error(Tcs) ->
+    {error,"malformed number near '" ++ Tcs ++ "'"}.
 
-hex_float(Mcs, [], Line) ->
-    case hex_mantissa(Mcs) of
-        {float,M} -> {token,{'NUMERAL',Line,M}};
-        error -> {error,"malformed number"}
+dec_number_split(Tcs0) ->
+    Digit = fun (C) -> ?DIGIT(C) end,
+    %% The whole number characters.
+    {Hcs,Tcs1} = lists:splitwith(Digit, Tcs0),
+    %% The fraction characters.
+    {Fcs,Tcs2} = dec_number_split_fraction(Tcs1),
+    %% The exponent characters.
+    {Ecs,Rest} = dec_number_split_exponent(Tcs2),
+    {Hcs,Fcs,Ecs,Rest}.
+
+dec_number_split_fraction([$. | Fcs0]) ->
+    {Fcs1,Frest} = lists:splitwith(fun (C) -> ?DIGIT(C) end, Fcs0),
+    {[$.|Fcs1],Frest};
+dec_number_split_fraction(Tcs) ->
+    {[],Tcs}.
+
+dec_number_split_exponent([P | Pcs0]) when P =:= $e ; P =:= $E ->
+    Digit = fun (C) -> ?DIGIT(C) end,
+    case Pcs0 of
+        [S | Pcs1] when S =:= $+ ; S =:= $- ->
+            {Pcs2,Rest} = lists:splitwith(Digit, Pcs1),
+            {[P,S|Pcs2],Rest};
+        Pcs1 ->
+            {Pcs2,Rest} = lists:splitwith(Digit, Pcs1),
+            {[P|Pcs2],Rest}
     end;
-hex_float(Mcs, Ecs, Line) ->
-    case hex_mantissa(Mcs) of
-        {float,M} ->
-            case catch list_to_integer(Ecs, 10) of
-                {'EXIT',_} -> {error,"malformed number"};
-                E -> {token,{'NUMERAL',Line,M * math:pow(2, E)}}
-            end;
-        error -> {error,"malformed number"}
+dec_number_split_exponent(Tcs) ->
+    {[],Tcs}.
+
+dec_number_fraction(".", DW) -> float(DW);
+dec_number_fraction([$. | Fcs], DW) ->
+    DW + list_to_float("0." ++ Fcs);
+dec_number_fraction([], DW) -> DW.
+
+dec_number_exponent([_E | Ecs], DF) ->
+    DF * math:pow(10, list_to_integer(Ecs));
+dec_number_exponent([], DF) -> DF.
+
+%% hex_number_token(TokenChars, TokenLine)
+%%     {token,{'NUMERAL',TokenLine,Float}} | {error,E}.
+%%  Build either an integer or a float from a hexadecimal number
+%%  string. We first collect the specific number section, then we
+%%  create the number. This makes it easier to keep track of which
+%%  sections we need to make Lua compliant Luerl numbers, as Lua has
+%%  some very "specific" handling.
+%%
+%%  0[xX]\.{H}+([pP][-+]?{D}+)?{NAME}* :
+%%  0[xX]{H}+\.?{H}*([pP][-+]?{D}+)?{NAME}*
+
+hex_number_token([$0,X|TokenChars], TokenLine) ->
+    io:format("hnt ~p\n", [hex_number_split(TokenChars)]),
+    Result = case hex_number_split(TokenChars) of
+                 %% If there is anything after the number sections then
+                 %% it is an error!
+                 {_,_,_,Rest} when Rest =/= [] -> error;
+                 {[],[],[],_Rest} -> error;     %Nothing at all
+                 {[],[],_Ecs,_Rest} -> error;   %No number data
+                 {[],".",_Ecs,_Rest} -> error;  %Only "empty" fraction
+                 {_,_,[_P],_Rest} -> error;     %Only "empty" exponent
+                 {Hcs,Fcs,Ecs,_Rest} ->
+                     HW = list_to_integer("0" ++ Hcs, 16),
+                     io:format("hw ~p\n", [HW]),
+                     HF = hex_number_fraction(Fcs, HW),
+                     io:format("hf ~p\n", [HF]),
+                     Hnum = hex_number_exponent(Ecs, HF),
+                     io:format("hn ~p\n", [Hnum]),
+                     {ok,Hnum}
+             end,
+    case Result of
+        {ok,Number} ->
+            {token,{'NUMERAL',TokenLine,Number}};
+        error ->
+            number_token_error([$0,X|TokenChars])
     end.
 
-hex_mantissa(Mcs) ->
-    case lists:splitwith(fun (C) -> C =/= $. end, Mcs) of
-        {[],[]} -> error;                       %Nothing at all
-        {[],[$.]} -> error;                     %Only a '.'
-        {[],[$.|Fcs]} -> {float,hex_fraction(Fcs, 16.0, 0.0)};
-        {Hcs,[]} -> {float,float(list_to_integer(Hcs, 16))};
-        {Hcs,[$.|Fcs]} ->
-            H = float(list_to_integer(Hcs, 16)),
-            {float,hex_fraction(Fcs, 16.0, H)}
-    end.
+hex_number_split(Tcs0) ->
+    Hex = fun (C) -> ?HEX(C) end,
+    %% Digit = fun (C) -> ?DIGIT(C) end,
+    %% The whole number characters.
+    {Hcs,Tcs1} = lists:splitwith(Hex, Tcs0),
+    %% The fraction characters.
+    {Fcs,Tcs2} = hex_number_split_fraction(Tcs1),
+    %% The exponent characters.
+    {Ecs,Rest} = hex_number_split_exponent(Tcs2),
+    io:format("hnse ~p ~p\n", [Tcs2,Ecs]),
+    {Hcs,Fcs,Ecs,Rest}.
 
-hex_fraction([C|Cs], Pow, SoFar) when C >= $0, C =< $9 ->
-    hex_fraction(Cs, Pow*16, SoFar + (C - $0)/Pow);
-hex_fraction([C|Cs], Pow, SoFar) when C >= $a, C =< $f ->
-    hex_fraction(Cs, Pow*16, SoFar + (C - $a + 10)/Pow);
-hex_fraction([C|Cs], Pow, SoFar) when C >= $A, C =< $F ->
-    hex_fraction(Cs, Pow*16, SoFar + (C - $A + 10)/Pow);
-hex_fraction([], _Pow, SoFar) -> SoFar.
+hex_number_split_fraction([$. | Fcs0]) ->
+    {Fcs1,Frest} = lists:splitwith(fun (C) -> ?HEX(C) end, Fcs0),
+    {[$.|Fcs1],Frest};
+hex_number_split_fraction(Tcs) ->
+    {[],Tcs}.
+
+hex_number_split_exponent([P | Pcs0]) when P =:= $p ; P =:= $P ->
+    Digit = fun (C) -> ?DIGIT(C) end,
+    case Pcs0 of
+        [S | Pcs1] when S =:= $+ ; S =:= $- ->
+            {Pcs2,Rest} = lists:splitwith(Digit, Pcs1),
+            {[P,S|Pcs2],Rest};
+        Pcs1 ->
+            {Pcs2,Rest} = lists:splitwith(Digit, Pcs1),
+            {[P|Pcs2],Rest}
+    end;
+hex_number_split_exponent(Tcs) ->
+    {[],Tcs}.
+
+hex_number_fraction([$. | Fcs], HW) ->
+    {HF,_} = hex_number_fraction(Fcs, 16.0, HW + 0.0),
+    HF;
+hex_number_fraction([], HW) -> HW.
+
+hex_number_exponent([_P | Ecs], HF) ->
+    HF * math:pow(2, list_to_integer(Ecs));
+hex_number_exponent([], HF) -> HF.
+
+hex_number_fraction([C|Cs], Pow, SoFar) when C >= $0, C =< $9 ->
+    hex_number_fraction(Cs, Pow*16.0, SoFar + (C - $0)/Pow);
+hex_number_fraction([C|Cs], Pow, SoFar) when C >= $a, C =< $f ->
+    hex_number_fraction(Cs, Pow*16.0, SoFar + (C - $a + 10)/Pow);
+hex_number_fraction([C|Cs], Pow, SoFar) when C >= $A, C =< $F ->
+    hex_number_fraction(Cs, Pow*16.0, SoFar + (C - $A + 10)/Pow);
+hex_number_fraction(Cs, _Pow, SoFar) ->
+    {SoFar,Cs}.
 
 %% string_token(InputChars, Length, Line) ->
 %%     {token,{'LITERALSTRING',Line,Cs}} | {error,Error}.
 %%  Convert an input string into the corresponding string characters.
 %%  We know that the input string is correct.
 
-string_token(Cs0, Len, L) ->
-    Cs1 = string:substr(Cs0, 2, Len - 2),       %Strip quotes
+string_token([Qc|Cs0], _Len, L) ->
+    Cs1 = lists:droplast(Cs0),                  %Strip trailing quote
     try
         Bytes = string_chars(Cs1),
         String = iolist_to_binary(Bytes),
         {token,{'LITERALSTRING',L,String}}
     catch
-        _:_ ->
-            {error,"illegal string"}
+        throw:{string_error,What} ->            %Specific error message
+            string_token_error(What, Qc);
+        _:_ ->                                  %General error message
+            string_token_error("illegal string", Qc)
     end.
+
+string_token_error(What, Qc) ->
+    {error,What ++ " near '" ++ [Qc] ++ "'"}.
 
 %% string_chars(Chars)
 %% chars(Chars)
@@ -264,14 +369,26 @@ string_chars([$\\ | Cs], Acc) ->
     string_bq_chars(Cs, Acc);
 string_chars([$\n | _], _Acc) ->
     throw(string_error);
-string_chars([C | Cs], Acc) ->
-    string_chars(Cs, [C | Acc]);
+string_chars([C0 | Cs], Acc) ->
+    C1 = string_unicode_char(C0),
+    string_chars(Cs, [C1|Acc]);
 string_chars([], Acc) ->
     lists:reverse(Acc).
 
+%% string_unicode_char(Char) -> UnicodeChars.
+%%  If Char is not an ascii then handle it as unicode.
+
+string_unicode_char(C) when ?ASCII(C) -> C;
+string_unicode_char(C0) ->
+    case unicode:characters_to_binary([C0]) of
+        Bin when is_binary(Bin) ->
+            Bin;
+        _Error ->
+            throw(string_error)
+    end.
+
 %% string_bq_chars(Chars, Accumulator)
-%%  Handle the backquotes characters. These always fit directly into
-%%  one byte and are never UTF-8 encoded.
+%%  Handle the backquotes characters.
 
 string_bq_chars([C1|Cs0], Acc) when ?DIGIT(C1) -> %1-3 decimal digits
     I1 = C1 - $0,
@@ -287,37 +404,35 @@ string_bq_chars([C1|Cs0], Acc) when ?DIGIT(C1) -> %1-3 decimal digits
     end,
     string_chars(Cs1, [Byte | Acc]);
 string_bq_chars([$x,C1,C2|Cs], Acc) ->          %2 hex digits
-    case hex_char(C1) and hex_char(C2) of
+    case ?HEX(C1) and ?HEX(C2) of
         true ->
             Byte = hex_val(C1)*16 + hex_val(C2),
             string_chars(Cs, [Byte|Acc]);
-        false -> throw(string_error)
+        false -> throw({string_error,"hexadecimal digit expected"})
     end;
 string_bq_chars([$u,${|Cs], Acc) ->             %Explicit utf-8 character
-    string_bq_chars_utf8(Cs, Acc);
+    string_bq_chars_utf8(Cs, 0, Acc);
 string_bq_chars([$z|Cs], Acc) ->                %Skip whitespace
     string_chars(skip_space(Cs), Acc);
 string_bq_chars([C|Cs], Acc) ->
     case escape_char(C) of
-        error -> throw(string_error);
+        error -> throw({string_error,"invalid escape sequence"});
         Esc -> string_chars(Cs, [Esc|Acc])
     end;
 string_bq_chars([], Acc) ->
     Acc.
 
-string_bq_chars_utf8(Cs0, Acc) ->
-    case lists:splitwith(fun (C) -> ?HEX(C) end, Cs0) of
-        {Hcs,"}" ++ Cs1} when Hcs =/= [] ->
-            Hex = list_to_integer(Hcs, 16),
-            case unicode:characters_to_binary([Hex]) of
-                HexBin when is_binary(HexBin) ->
-                    string_chars(Cs1, [HexBin | Acc]);
-                _Error ->
-                    throw(string_error)
-            end;
+string_bq_chars_utf8([C|Cs], Uchar, Acc) when ?HEX(C) ->
+    string_bq_chars_utf8(Cs, Uchar*16 + hex_val(C), Acc);
+string_bq_chars_utf8([$}|Cs], Uchar, Acc) ->
+    case unicode:characters_to_binary([Uchar]) of
+        Bin when is_binary(Bin) ->
+            string_chars(Cs, [Bin|Acc]);
         _Error ->
-            throw(string_error)
-    end.
+            throw({string_error,"UTF-8 value error"})
+    end;
+string_bq_chars_utf8(_Cs, _Uchar, _Acc) ->
+    throw({string_error,"missing '}'"}).
 
 skip_space([C|Cs]) when C >= 0, C =< $\s -> skip_space(Cs);
 skip_space(Cs) -> Cs.
@@ -338,13 +453,20 @@ long_string_token(Cs0, Len, BrLen, Line) ->
         {token,{'LITERALSTRING',Line,String}}
     catch
         _:_ ->
-            {error,"illegal string"}
+            {error,"illegal long string"}
     end.
 
-hex_char(C) when C >= $0, C =< $9 -> true;
-hex_char(C) when C >= $a, C =< $f -> true;
-hex_char(C) when C >= $A, C =< $F -> true;
-hex_char(_) -> false.
+long_string_chars([C | Cs], Acc) when ?ASCII(C) ->
+    long_string_chars(Cs, [C|Acc]);
+long_string_chars([C | Cs], Acc) ->             %This could be unicode
+    case unicode:characters_to_binary([C]) of
+        Bin when is_binary(Bin) ->
+            long_string_chars(Cs, [Bin|Acc]);
+        _Error ->
+            throw(long_string_error)
+    end;
+long_string_chars([], Acc) ->
+    lists:reverse(Acc).
 
 hex_val(C) when C >= $0, C =< $9 -> C - $0;
 hex_val(C) when C >= $a, C =< $f -> C - $a + 10;


### PR DESCRIPTION
We fix the scanner so it handles numbers in a Lua compliant manner and signals errors in a compatible way. E.g. the sequence "12.3e4fgh" now generates and error whereas before it generated a number and a name. This is exactly what Lua does. We also make strings scan the same way.

The parser now handles attributes in local variables though we don't use this feature. Also we make sure that local functions can do recursive calls and also reference their own name in the function. Again to be Lua compliant.