### PR TITLE
fix: illegal_token displaying integer value instead of characters

### DIFF
--- a/src/luerl_scan.xrl
+++ b/src/luerl_scan.xrl
@@ -161,8 +161,7 @@ Erlang code.
 %%  Generate a more Lua compatible error message.
 
 illegal_token(Chars, _Line) ->
-	C = hd(Chars),
-	{error,"syntax error near '<\\" ++ integer_to_list(C) ++ ">'"}.
+	{error,"syntax error near '" ++ Chars ++ "'"}.
 
 %% name_token(Chars, Line) ->
 %%     {token,{'NAME',Line,Symbol}} | {Name,Line} | {error,E}.

--- a/test/luerl_scan_tests.erl
+++ b/test/luerl_scan_tests.erl
@@ -1,0 +1,21 @@
+%% Copyright (C) 2025 Robert Virding, Dave Lucia
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%       http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(luerl_scan_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+syntax_error_test() ->
+    State = luerl:init(),
+    ?assertMatch({error, [{1,luerl_scan, {user,"syntax error near '\"'"}}], []}, luerl:do(<<"print(\"hi)">>, State)).


### PR DESCRIPTION
Instead of

```
syntax error near '<\\39>'
```

It will now display

```
syntax error near '"'
```