### PR TITLE
Implement string.gmatch iterator

### DIFF
--- a/src/luerl_lib_string.erl
+++ b/src/luerl_lib_string.erl
@@ -184,11 +184,57 @@ format(_, [F|As], St0) ->
     end;
 format(_, As, St) -> badarg_error(format, As, St).
 
--spec gmatch(_, [_], _) -> no_return().		%To keep dialyzer quiet
-
 %% gmatch(String, Pattern) -> [Function].
+%%  Returns an iterator function that, each time it is called, returns
+%%  the next captures from pattern over string s. If pattern has no
+%%  captures, the whole match is returned.
+%%
+%%  Implementation: pre-compute all matches using gsub_match_loop/6,
+%%  store the match list in the luerl private state under a unique
+%%  ref, and return an erl_func iterator that pops matches on each
+%%  call.
 
-gmatch(_, As, St) -> badarg_error(gmatch, As, St).
+gmatch(_, As, St) ->
+    case luerl_lib:conv_list(As, [lua_string,lua_string]) of
+	[S,P] ->
+	    do_gmatch(S, P, St);
+	_ -> badarg_error(gmatch, As, St)
+    end.
+
+do_gmatch(S, P, St0) ->
+    case pat(binary_to_list(P)) of
+	{ok,{Pat,_},_} ->
+	    L = byte_size(S),
+	    Matches = gsub_match_loop(S, L, Pat, 1, 1, all),
+	    %% Store the match state in private data.
+	    Ref = make_ref(),
+	    St1 = luerl:put_private(Ref, {Matches, S}, St0),
+	    %% Build the iterator function.
+	    Iter = #erl_func{code=fun(_, St2) ->
+		case luerl:get_private(Ref, St2) of
+		    {[], _} ->
+			St3 = luerl:delete_private(Ref, St2),
+			{[nil], St3};
+		    {[Cas|Rest], S1} ->
+			St3 = luerl:put_private(Ref, {Rest, S1}, St2),
+			Vals = gmatch_vals(Cas, S1),
+			{Vals, St3}
+		end
+	    end},
+	    {[Iter], St1};
+	{error,E} -> lua_error(E, St0)
+    end.
+
+%% gmatch_vals(Captures, String) -> [Values].
+%%  Extract the match values from a capture list.
+%%  If there are explicit captures (length > 1), return only the
+%%  sub-captures (skip the whole-match entry at the head).
+%%  If no explicit captures, return the whole match.
+
+gmatch_vals([Ca], S) ->
+    [match_cap(Ca, S)];
+gmatch_vals([_Ca|Cas], S) ->
+    match_caps(Cas, S).
 
 %% gsub(String, Pattern, Repl [, N]) -> [String]
 

--- a/test/luerl_str_gmatch_tests.erl
+++ b/test/luerl_str_gmatch_tests.erl
@@ -1,0 +1,113 @@
+%% Copyright (c) 2026 Robert Virding
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% File    : luerl_str_gmatch_tests.erl
+%% Purpose : Tests for string.gmatch/2.
+
+-module(luerl_str_gmatch_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Helper: run Lua code and return decoded results.
+eval(Code) ->
+    St = luerl:init(),
+    {ok, Res, _St1} = luerl:do(Code, St),
+    Res.
+
+%% Basic word iteration using %a+ pattern.
+gmatch_words_test() ->
+    Res = eval(<<"local t = {}\n"
+		 "for w in string.gmatch(\"hello world foo\", \"%a+\") do\n"
+		 "  t[#t+1] = w\n"
+		 "end\n"
+		 "return t[1], t[2], t[3]">>),
+    ?assertEqual([<<"hello">>, <<"world">>, <<"foo">>], Res).
+
+%% Digit extraction.
+gmatch_digits_test() ->
+    Res = eval(<<"local t = {}\n"
+		 "for d in string.gmatch(\"x1y22z333\", \"%d+\") do\n"
+		 "  t[#t+1] = d\n"
+		 "end\n"
+		 "return t[1], t[2], t[3]">>),
+    ?assertEqual([<<"1">>, <<"22">>, <<"333">>], Res).
+
+%% Multiple captures: key=value pairs.
+gmatch_captures_test() ->
+    Res = eval(<<"local keys, vals = {}, {}\n"
+		 "for k, v in string.gmatch(\"a=1,b=2,c=3\", \"(%a+)=(%d+)\") do\n"
+		 "  keys[#keys+1] = k\n"
+		 "  vals[#vals+1] = v\n"
+		 "end\n"
+		 "return keys[1], vals[1], keys[2], vals[2], keys[3], vals[3]">>),
+    ?assertEqual([<<"a">>, <<"1">>, <<"b">>, <<"2">>, <<"c">>, <<"3">>], Res).
+
+%% No matches: iterator returns nil immediately.
+gmatch_no_match_test() ->
+    Res = eval(<<"local count = 0\n"
+		 "for w in string.gmatch(\"12345\", \"%a+\") do\n"
+		 "  count = count + 1\n"
+		 "end\n"
+		 "return count">>),
+    ?assertEqual([0], Res).
+
+%% Single character matches.
+gmatch_single_chars_test() ->
+    Res = eval(<<"local t = {}\n"
+		 "for c in string.gmatch(\"abc\", \".\") do\n"
+		 "  t[#t+1] = c\n"
+		 "end\n"
+		 "return t[1], t[2], t[3], #t">>),
+    ?assertEqual([<<"a">>, <<"b">>, <<"c">>, 3], Res).
+
+%% Empty string: no iterations.
+gmatch_empty_string_test() ->
+    Res = eval(<<"local count = 0\n"
+		 "for w in string.gmatch(\"\", \"%a+\") do\n"
+		 "  count = count + 1\n"
+		 "end\n"
+		 "return count">>),
+    ?assertEqual([0], Res).
+
+%% Pattern with anchored start should only match at the beginning.
+%% In standard Lua, gmatch with ^ returns at most one match.
+gmatch_anchor_test() ->
+    Res = eval(<<"local t = {}\n"
+		 "for w in string.gmatch(\"hello world\", \"^%a+\") do\n"
+		 "  t[#t+1] = w\n"
+		 "end\n"
+		 "return t[1], #t">>),
+    ?assertEqual([<<"hello">>, 1], Res).
+
+%% Typical use: building a table from key=value string (Lua book example).
+gmatch_table_build_test() ->
+    Res = eval(<<"local t = {}\n"
+		 "local s = \"from=world, to=hello\"\n"
+		 "for k, v in string.gmatch(s, \"(%w+)=(%w+)\") do\n"
+		 "  t[k] = v\n"
+		 "end\n"
+		 "return t[\"from\"], t[\"to\"]">>),
+    ?assertEqual([<<"world">>, <<"hello">>], Res).
+
+%% Multiple iterators can coexist independently.
+gmatch_multiple_iterators_test() ->
+    Res = eval(<<"local r = {}\n"
+		 "local iter1 = string.gmatch(\"a b c\", \"%a\")\n"
+		 "local iter2 = string.gmatch(\"1 2 3\", \"%d\")\n"
+		 "r[1] = iter1()\n"
+		 "r[2] = iter2()\n"
+		 "r[3] = iter1()\n"
+		 "r[4] = iter2()\n"
+		 "return r[1], r[2], r[3], r[4]">>),
+    ?assertEqual([<<"a">>, <<"1">>, <<"b">>, <<"2">>], Res).


### PR DESCRIPTION
Implements `string.gmatch(s, pattern)`.

- This was previously a stub that always raised `badarg`
- This change implements the function using the existing pattern-matching engine.
- The implementation is pre-computed:
  - Pre-compute all matches eagerly via `gsub_match_loop/6`
  - Store the match list in `luerl` private state under a unique ref
  - Return an `erl_func` iterator that pops from the match list on each call.
  - The iterator state is cleaned up when the match list is exhausted.
  - Use `luerl:put_private`, `get_private` and `delete_private` to thread iterator state through the `luerl` state record rather than the process dictionary, keeping the implementation pure.
- The eager approach follows `gsub`, which also pre-computes all matches via `gsub_match_loop/6`, before processing replacements.
  - Both functions share the same match engine, so a future lazy stepper would benefit both equally.
- Added 9 new tests in luerl_str_gmatch_tests.erl.

**Handles**
- Basic iteration (word splitting, digit extraction)
- Multiple captures (key=value patterns)
- Single character matches
- Anchored patterns (^)
- No-match case (iterator immediately yields nil)
- Empty input string
- Multiple independent iterators
- Typical Lua book pattern: building tables from key=value strings

Should fix #150