### PR TITLE
feat: export luerlstate/0 and luerldata/0 types

### DIFF
--- a/src/luerl.erl
+++ b/src/luerl.erl
@@ -43,6 +43,8 @@ or
 
 `luerl:do(~\"return 'árvíztűrő tükörfúrógép'\", St0)`").
 
+-export_type([luerlstate/0, luerldata/0]).
+
 %% Basic user API to luerl.
 -export([init/0,gc/1,
          load/2,load/3,loadfile/2,loadfile/3,


### PR DESCRIPTION
## Summary

Add `-export_type([luerlstate/0, luerldata/0])` to `luerl.erl`.

These types are defined in `luerl.hrl` and used throughout the public API specs, but were never exported. This makes it impossible for downstream projects to reference them in their own type specs or use gradual type checkers like eqWAlizer.

One-line change, all existing tests pass.

## Test plan
- [x] `rebar3 eunit` (28 tests, 0 failures)
- [x] `rebar3 compile`