### PR TITLE
Fix local function self-recursion

### DIFF
--- a/src/luerl_comp_normalise.erl
+++ b/src/luerl_comp_normalise.erl
@@ -36,11 +36,13 @@ chunk(Code0, #cinfo{opts=Opts}=Ci0) ->
     {ok,Code1}.
 
 stmts([{local,L,{functiondef,Lf,Name,Pars,Block}}|Ss], St) ->
-    %% Need to split this up to handle references to Name in the function.
+    %% Need to split this up to handle references to Name in the
+    %% function. Desugar to "local Name; Name = function ... end" so
+    %% the closure captures the declared local and recursion works.
     Fdef = {functiondef,Lf,Pars,Block},
     stmts([{local, L, {assign, L, [Name], [{nil,L}]}},
            {';',L},
-           {local, Lf, {assign, Lf, [Name], [Fdef]}} | Ss],
+           {assign, Lf, [Name], [Fdef]} | Ss],
           St);
 stmts([{';',_}|Ss], St) -> stmts(Ss, St);	%No-op so we drop it
 stmts([S0|Ss0], St0) ->

--- a/test/luerl_funcall_tests.erl
+++ b/test/luerl_funcall_tests.erl
@@ -190,5 +190,24 @@ newindex_metamethod_test() ->
     ?assertEqual(456, TVal),
     ?assertEqual(nil, MVal).
 
+local_function_recursion_test() ->
+    State = luerl:init(),
+    Chunk = <<"local function fact(n)\n"
+              "  if n <= 1 then return 1 else return n * fact(n - 1) end\n"
+              "end\n"
+              "return fact(5)">>,
+    {ok, [Res], _State1} = luerl:do_dec(Chunk, State),
+    ?assertEqual(120, Res).
+
+local_assign_function_recursion_test() ->
+    State = luerl:init(),
+    Chunk = <<"local fact\n"
+              "fact = function(n)\n"
+              "  if n <= 1 then return 1 else return n * fact(n - 1) end\n"
+              "end\n"
+              "return fact(5)">>,
+    {ok, [Res], _State1} = luerl:do_dec(Chunk, State),
+    ?assertEqual(120, Res).
+
 bad_return_value(_Arg, _Args, State) ->
     lua_error(something_bad_happened, State).


### PR DESCRIPTION
`local function f() ... end` cannot call itself recursively:

```lua
local function fact(n) if n <= 1 then return 1 else return n * fact(n - 1) end end
return fact(5)
-- expected 120, got: lua_error {undefined_function, nil}
```

Root cause: `luerl_comp_normalise:stmts/2` desugars `local function` into two statements that are **both** `local` declarations. The second `local` introduces a fresh binding for the name, and since the function-definition expression is compiled in the scope before that binding exists, the closure captures the first binding — which remains nil — so recursive calls hit `undefined_function`.

Standard Lua semantics (Lua 5.3 manual §3.4.11) define the sugar as `local f; f = function() ... end` — a plain assignment to the already-declared local. This PR changes the desugaring accordingly (the explicit form `local f` then `f = function ... end` already worked in Luerl; only the sugar was broken).

Adds two EUnit regression tests in `luerl_funcall_tests`: the sugar form and the explicit declare-then-assign form, both asserting `fact(5) == 120`. Full EUnit + CT suites pass.
