### PR TITLE
Treat the private store as a gc root

### DIFF
--- a/src/luerl_heap.erl
+++ b/src/luerl_heap.erl
@@ -596,10 +596,14 @@ gc(#luerl{tabs=#tstruct{data=Tt0,free=Tf0}=Tab0,
           envs=#tstruct{data=Et0,free=Ef0}=Env0,
           usds=#tstruct{data=Ut0,free=Uf0}=Usd0,
           fncs=#tstruct{data=Ft0,free=Ff0}=Fnc0,
-          g=G,stk=Stk,cs=Cs,meta=Meta}=St) ->
-    %% The root set consisting of global table and stack.
+          g=G,stk=Stk,cs=Cs,meta=Meta,private=Priv}=St) ->
+    %% The root set consisting of global table, stack and private store.
+    %% The private store holds values the embedder put there with
+    %% luerl:put_private/3. They are unreachable from Lua by design, so
+    %% without them here the collector frees the tables underneath any
+    %% reference kept in it and the embedder's next decode fails.
     Root = [Meta#meta.nil,Meta#meta.boolean,Meta#meta.number,Meta#meta.string,
-            G|Stk],
+            G|Stk] ++ maps:values(Priv),
     %% Mark all seen tables and frames, i.e. return them.
     GcT = #gct{t=Tt0,s=[]},
     GcE = #gct{t=Et0,s=[]},

--- a/test/luerl_tests.erl
+++ b/test/luerl_tests.erl
@@ -54,3 +54,14 @@ private_test() ->
 loadfile_only_comments_test() ->
     State1 = luerl:init(),
     ?assertMatch({ok, _, _}, luerl:loadfile("./test/luerl_return_SUITE_data/only_comments.lua", State1)).
+
+%% A reference put in the private store must survive a collection. It is
+%% unreachable from Lua by design, so if gc does not treat the store as a
+%% root it frees the table underneath and the next decode fails.
+private_store_survives_gc_test() ->
+    St0 = luerl:init(),
+    {Ref,St1} = luerl:encode(#{<<"keep">> => <<"me">>}, St0),
+    St2 = luerl:put_private(mine, Ref, St1),
+    St3 = luerl:gc(St2),
+    ?assertEqual([{<<"keep">>,<<"me">>}],
+                 luerl:decode(luerl:get_private(mine, St3), St3)).


### PR DESCRIPTION
`luerl:put_private/3` is documented as putting "a private `Value` under `Key`
that is not exposed to the runtime". `luerl_heap:gc/1`'s root set is
`[Meta..., G | Stk]` plus the call stack (`luerl_heap.erl:601-602`) and does
not include the private store.

So a reference kept there is unreachable from the collector's point of view.
The collector frees the table underneath it, the reference survives as an
opaque term, and the embedder's next `decode/2` fails on a reclaimed index:

```erlang
St0 = luerl:init(),
{Ref, St1} = luerl:encode(#{<<"keep">> => <<"me">>}, St0),
St2 = luerl:put_private(mine, Ref, St1),
St3 = luerl:gc(St2),
luerl:decode(luerl:get_private(mine, St3), St3).
%% ** exception error: {badkey,14}
```

The failure is delayed and does not point at the collection that caused it,
and the API is exactly the one that invites keeping a reference there.

Adding the store to the root set is one line. Included is a regression test,
which fails on `develop` with `{badkey,14}`.

## Verification

`rebar3 eunit` 31/0 (30 existing plus the new test) and `rebar3 ct` 11/11.

Found while investigating unbounded Luerl memory growth in a game backend.
The workaround without this is to anchor the value in a global for the
duration of the collection and remove it straight after, which is visible to
script code in between.
